### PR TITLE
Update MySQL version in docker-compose from 5.7 to 8.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     stdin_open: true
 
   db:
-    image: mysql:5.7
+    image: mysql:8.0
     volumes:
       - mysql_data:/var/lib/mysql/
     environment:


### PR DESCRIPTION
MySQLのバージョン上げさせていただきたいです🙇
理由は2つで
・5.7はサポート終了しており、8.0の方が基本機能が充実していてパフォーマンスが良い（この記事が詳しそうです：https://www.issoh.co.jp/tech/details/4251/#MySQL_57_MySQL_80-2）
・Apple M1以降のチップだとDockerイメージのビルドに追加設定が必要。

懸念点なければapproveお願いします！