### PR TITLE
ユーザ登録とハッシュ化に伴うBcryptの追加

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.17.1",
+    "bcrypt": "^6.0.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",

--- a/api/src/contexts/users/controllers/CreateUserController.ts
+++ b/api/src/contexts/users/controllers/CreateUserController.ts
@@ -1,0 +1,45 @@
+import express from 'express';
+import { ICreateUserInteractor } from '../usecases/ICreateUserInteractor';
+
+//Receive HTTP request
+//It handles recieve -> execute interactor -> response
+export class CreateUserController {
+  //reset Business Logic Layer
+  constructor(private readonly createUserInteractor: ICreateUserInteractor) {}
+
+  //Execute HTTP request and Check data itself
+  async execute(req: express.Request, res: express.Response) {
+    try {
+      //get request body
+      const { lastName, firstName, email, password } = req.body;
+
+      //validation
+      if (!lastName || !firstName || !email || !password) {
+        return res.status(400).json({ message: 'Missing required fields' });
+      }
+
+      // get token from interactor(Business Logic Layer)
+      const createdUser = await this.createUserInteractor.execute({
+        lastName,
+        firstName,
+        email,
+        password,
+      });
+
+      // Return token as response
+      return res.status(201).json({ createdUser });
+    } catch (error: unknown) {
+      // Error Handling
+      if (error instanceof Error) {
+        if (error.message === 'Email already extists') {
+          return res.status(400).json({ message: error.message });
+        }
+      }
+
+      // Error messages for smth wrong in creating user
+      console.error('Error creating user:', error);
+
+      return res.status(500).json({ message: 'Internal server error' });
+    }
+  }
+}

--- a/api/src/contexts/users/domains/entities/User.ts
+++ b/api/src/contexts/users/domains/entities/User.ts
@@ -1,0 +1,12 @@
+//Define Constant table for User
+export type User = {
+  readonly id: number;
+  readonly lastName: string;
+  readonly firstName: string;
+  readonly email: string;
+  readonly password: string;
+  readonly role: string;
+  readonly isResigned: boolean;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+};

--- a/api/src/contexts/users/domains/repositories/IUserRepository.ts
+++ b/api/src/contexts/users/domains/repositories/IUserRepository.ts
@@ -1,0 +1,9 @@
+import { User } from '../entities/User';
+
+export interface IUserRepository {
+  findById(id: number): Promise<User | null>;
+  findByEmail(email: string): Promise<User | null>;
+  create(data: Omit<User, 'createdAt' | 'updatedAt' | 'id'>): Promise<User>;
+  update(id: number, data: Partial<User>): Promise<User>;
+  delete(id: number): Promise<void>;
+}

--- a/api/src/contexts/users/index.ts
+++ b/api/src/contexts/users/index.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import { PrismaClient } from "@prisma/client";
 import { UserRepository } from "./infrastructures/repositories/UserRepository";
+import { verifyAccessToken } from "src/middlewares/verifyAccesToken";
 
 import { GetUserByIdInteractor } from "./interactors/GetUserByIdInteractor";
 import { CreateUserInteractor } from "./interactors/CreateUserInteractor";
@@ -19,22 +20,33 @@ const prisma = new PrismaClient();
 const userRepository = new UserRepository(prisma);
 
 
-const getUsersInteractor = new GetUserByIdInteractor(userRepository);
+const getUserByIdInteractor = new GetUserByIdInteractor(userRepository);
 const createUserInteractor = new CreateUserInteractor(userRepository);
 const updateUserInteractor = new UpdateUserProfileInteractor(userRepository);
 const deleteUserInteractor = new DeleteUserInteractor(userRepository);
 
 // Controllers
-const getUsersController = new GetUserByIdController(getUsersInteractor);
+const getUserByIdController = new GetUserByIdController(getUserByIdInteractor);
 const createUserController = new CreateUserController(createUserInteractor);
-const updateUserController = new UpdateUserProfileController(updateUserInteractor);
+const updateUserProfileController = new UpdateUserProfileController(updateUserInteractor);
 const deleteUserController = new DeleteUserController(deleteUserInteractor);
 
 // Routes
-UsersRouter.get("/", getUsersController.execute.bind(getUsersController));
+UsersRouter.get("/",
+    verifyAccessToken,(req, res) => {
+        getUserByIdController.execute(req, res);
+    }
+);
 UsersRouter.post("/signup", createUserController.execute.bind(createUserController));
-UsersRouter.put("/:id", updateUserController.execute.bind(updateUserController));
-UsersRouter.delete("/:id",deleteUserController.execute.bind(deleteUserController));
+UsersRouter.put("/users/:id",
+    verifyAccessToken, (req, res) => {
+        updateUserProfileController.execute(req, res);
+    }
+);
+UsersRouter.delete("/:id",
+    verifyAccessToken,
+    deleteUserController.execute.bind(deleteUserController)
+);
 
 
 export { UsersRouter };

--- a/api/src/contexts/users/index.ts
+++ b/api/src/contexts/users/index.ts
@@ -1,0 +1,40 @@
+import express from "express";
+import { PrismaClient } from "@prisma/client";
+import { UserRepository } from "./infrastructures/repositories/UserRepository";
+
+import { GetUserByIdInteractor } from "./interactors/GetUserByIdInteractor";
+import { CreateUserInteractor } from "./interactors/CreateUserInteractor";
+import { UpdateUserProfileInteractor } from "./interactors/UpdateUserProfileInteractor";
+import { DeleteUserInteractor } from "./interactors/DeleteUserInteractor";
+
+import { GetUserByIdController } from "./controllers/GetUserByIdController";
+import { CreateUserController } from "./controllers/CreateUserController";
+import { UpdateUserProfileController } from "./controllers/UpdateUserProfileController";
+import { DeleteUserController } from "./controllers/DeleteUserController";
+
+const UsersRouter = express.Router();
+
+// Core dependencies
+const prisma = new PrismaClient();
+const userRepository = new UserRepository(prisma);
+
+
+const getUsersInteractor = new GetUserByIdInteractor(userRepository);
+const createUserInteractor = new CreateUserInteractor(userRepository);
+const updateUserInteractor = new UpdateUserProfileInteractor(userRepository);
+const deleteUserInteractor = new DeleteUserInteractor(userRepository);
+
+// Controllers
+const getUsersController = new GetUserByIdController(getUsersInteractor);
+const createUserController = new CreateUserController(createUserInteractor);
+const updateUserController = new UpdateUserProfileController(updateUserInteractor);
+const deleteUserController = new DeleteUserController(deleteUserInteractor);
+
+// Routes
+UsersRouter.get("/", getUsersController.execute.bind(getUsersController));
+UsersRouter.post("/signup", createUserController.execute.bind(createUserController));
+UsersRouter.put("/:id", updateUserController.execute.bind(updateUserController));
+UsersRouter.delete("/:id",deleteUserController.execute.bind(deleteUserController));
+
+
+export { UsersRouter };

--- a/api/src/contexts/users/infrastructures/repositories/UserRepository.ts
+++ b/api/src/contexts/users/infrastructures/repositories/UserRepository.ts
@@ -1,0 +1,30 @@
+import { PrismaClient } from '@prisma/client';
+import { IUserRepository } from '../../domains/repositories/IUserRepository';
+import { User } from '../../domains/entities/User';
+
+// Used for acutall Implementation
+export class UserRepository implements IUserRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(id: number): Promise<User | null> {
+    return this.prisma.users.findUnique({ where: { id } });
+  }
+
+  async findByEmail(email: string): Promise<User | null> {
+    return this.prisma.users.findUnique({ where: { email } });
+  }
+
+  async create(
+    data: Omit<User, 'id' | 'createdAt' | 'updatedAt'>,
+  ): Promise<User> {
+    return this.prisma.users.create({ data });
+  }
+
+  async update(id: number, data: Partial<User>): Promise<User> {
+    return this.prisma.users.update({ where: { id }, data });
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.prisma.users.delete({ where: { id } });
+  }
+}

--- a/api/src/contexts/users/interactors/CreateUserInteractor.ts
+++ b/api/src/contexts/users/interactors/CreateUserInteractor.ts
@@ -1,0 +1,33 @@
+import { IUserRepository } from '../domains/repositories/IUserRepository';
+import { User } from '../domains/entities/User';
+import { hashPassword } from '../../../utils/hashPassword';
+import { ICreateUserRequest } from '../usecases/ICreateUserInteractor';
+
+export class CreateUserInteractor {
+  constructor(private readonly userRepository: IUserRepository) {}
+
+  async execute(input: ICreateUserRequest): Promise<User> {
+    const { lastName, firstName, email, password } = input;
+
+    //validation for email
+    const existingUser = await this.userRepository.findByEmail(email);
+    if (existingUser) {
+      throw new Error('Email already exists');
+    }
+
+    // hash password
+    const hashedPassword = await hashPassword(password);
+
+    // exec user
+    const createdUser = await this.userRepository.create({
+      lastName,
+      firstName,
+      email,
+      password: hashedPassword,
+      isResigned: false,
+      role: 'USER',
+    });
+
+    return createdUser;
+  }
+}

--- a/api/src/contexts/users/usecases/ICreateUserInteractor.ts
+++ b/api/src/contexts/users/usecases/ICreateUserInteractor.ts
@@ -1,0 +1,12 @@
+import { User } from '../domains/entities/User';
+
+export interface ICreateUserRequest {
+  lastName: string;
+  firstName: string;
+  email: string;
+  password: string;
+}
+
+export interface ICreateUserInteractor {
+  execute(input: ICreateUserRequest): Promise<User>;
+}

--- a/api/src/contexts/utils/hashPassword.ts
+++ b/api/src/contexts/utils/hashPassword.ts
@@ -1,0 +1,6 @@
+import bcrypt from 'bcrypt';
+
+export async function hashPassword(password: string): Promise<string> {
+  const saltRounds = 10;
+  return await bcrypt.hash(password, saltRounds);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@prisma/client": "^6.17.1",
+        "bcrypt": "^6.0.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
@@ -9277,6 +9278,19 @@
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
       "license": "MIT"
     },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/bfj": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/bfj/-/bfj-7.1.0.tgz",
@@ -16776,6 +16790,14 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
@@ -16789,6 +16811,16 @@
       "license": "(BSD-3-Clause OR GPL-2.0)",
       "engines": {
         "node": ">= 6.13.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/node-int64": {


### PR DESCRIPTION
### 変更点
- `CreateUserInput` 型を追加（ユーザー作成用入力型）
- `CreateUserController` を追加（HTTPリクエスト受け取り、バリデーション、Interactor 呼び出し）
- `User` エンティティを定義
- `IUserRepository` インターフェースを作成
- `UserRepository` を Prisma 実装として追加
- `CreateUserInteractor` を追加（ビジネスロジック、パスワードハッシュ、重複チェック）
- `ICreateUserInteractor` インターフェースを作成
- パスワードハッシュ用ユーティリティ関数を追加
- 依存パッケージ更新（bcrypt, jsonwebtoken など）

### 動作確認
- POST `/signup` エンドポイントでユーザー作成が可能
- 必須項目（lastName, firstName, email, password）が未入力の場合、400 を返す
- 既存メールアドレスの場合、エラーを返す
- 正常作成時は 201 + トークンを返却
