### PR TITLE
Feature/front/admin item list

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -12,6 +12,7 @@ import { UserLogin } from './pages/auth/UserLogin';
 import { UserSignup } from './pages/auth/UserSignup';
 import { AdminLogin } from './pages/auth/AdminLogin';
 import { AdminSignup } from './pages/auth/AdminSignup';
+import { AdminProductList } from './pages/admin/AdminProductList';
 
 function App(): React.JSX.Element {
   return (
@@ -26,6 +27,7 @@ function App(): React.JSX.Element {
             <Route path="/auth/user/signup" element={<UserSignup />} />
             <Route path="/auth/admin/login" element={<AdminLogin />} />
             <Route path="/auth/admin/signup" element={<AdminSignup />} />
+            <Route path="/admin/products" element={<AdminProductList />} />
           </Routes>
         </div>
       </div>

--- a/front/src/pages/admin/AdminProductList.tsx
+++ b/front/src/pages/admin/AdminProductList.tsx
@@ -1,0 +1,38 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import ProductCard from '../../components/ui/ProductCard';
+import { Item } from '@shared/schemas/item';
+import { ItemsApiService } from '../../services/api/items';
+
+export const AdminProductList: React.FC = () => {
+  const [items, setItems] = useState<Item[]>([]);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchItems = async (): Promise<void> => {
+      const response = await ItemsApiService.getAdminItems();
+      setItems(response.items);
+    };
+
+    fetchItems();
+  }, []);
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-bold">商品管理</h1>
+        <button
+          onClick={() => navigate('/admin/products/new')}
+          className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+        >
+          新規商品作成
+        </button>
+      </div>
+      <div className="grid grid-cols-4 gap-4">
+        {items.map((item) => (
+          <ProductCard key={item.id} item={item} />
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/front/src/services/api/items.ts
+++ b/front/src/services/api/items.ts
@@ -14,9 +14,12 @@ export class ItemsApiService {
   }
 
   static async getAdminItems(): Promise<ItemsResponse> {
-    const response = await axios.get<ItemsResponse>(`${API_BASE_URL}/items`, {
-      withCredentials: true,
-    });
+    const response = await axios.get<ItemsResponse>(
+      `${API_BASE_URL}/admin/items`,
+      {
+        withCredentials: true,
+      },
+    );
 
     return response.data;
   }

--- a/front/src/services/api/items.ts
+++ b/front/src/services/api/items.ts
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { Item } from '@shared/schemas/item';
 import { API_BASE_URL } from './config';
 
@@ -10,5 +11,13 @@ export class ItemsApiService {
     const response = await fetch(`${API_BASE_URL}/items`);
 
     return await response.json();
+  }
+
+  static async getAdminItems(): Promise<ItemsResponse> {
+    const response = await axios.get<ItemsResponse>(`${API_BASE_URL}/items`, {
+      withCredentials: true,
+    });
+
+    return response.data;
   }
 }


### PR DESCRIPTION
## 内容

管理者用の商品一覧画面の追加。

既存の商品一覧画面の「商品一覧」の文言を「商品管理」に変更。
商品作成用のボタン追加

## 共有

認証エラー時にログイン画面へのリダイレクトなどの機能の追加の必要がある

## 画面

<img width="1901" height="950" alt="image" src="https://github.com/user-attachments/assets/bf1bb8c7-97fb-4f62-a2e2-eb3dfa2332f4" />
