### PR TITLE
feature/admin-get-item

### DIFF
--- a/api/src/contexts/items/admin/controllers/GetItemImagesController.ts
+++ b/api/src/contexts/items/admin/controllers/GetItemImagesController.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import { GetRes } from '@shared/types/gets';
+import { IGetItemImagesInteractor } from '../usecases/IGetItemImagesInteractor';
+
+export class GetItemImagesController {
+    constructor(private readonly getItemImagesInteractor: IGetItemImagesInteractor) {}
+    
+    async execute(
+
+    req: express.Request<{id : string}>,
+    res: express.Response<GetRes['/items/:id/images']>
+
+    ){
+    const itemId = parseInt(req.params.id);
+
+    if (isNaN(itemId)) {
+      return res.status(400);
+    }
+
+    const images = await this.getItemImagesInteractor.execute(itemId);
+    
+    const responseImages = images.map((image) => ({
+      id: image.id,
+      itemId: image.itemId,
+      src: image.src,
+      order: image.order,
+      createdAt: image.createdAt,
+      updatedAt: image.updatedAt,
+    }));
+
+    res.status(200).json({ images: responseImages });
+  }
+}

--- a/api/src/contexts/items/admin/index.ts
+++ b/api/src/contexts/items/admin/index.ts
@@ -4,7 +4,10 @@ import { UpdateItemController } from './controllers/UpdateItemController';
 import { UpdateItemInteractor } from './interactors/UpdateItemInteractor';
 import { DeleteItemController } from './controllers/DeleteItemController';
 import { DeleteItemInteractor } from './interactors/DeleteItemInteractor';
+import { GetItemImagesController } from './controllers/GetItemImagesController';
+import { GetItemImagesInteractor } from './interactors/GetItemImagesInteractor';
 import { ItemRepository } from '../infrastructures/repositories/ItemRepository';
+import { ItemImageRepository } from '../infrastructures/repositories/ItemImageRepository';
 import { PrismaClient } from '@prisma/client';
 import express from 'express';
 import { verifyAccessToken } from '../../../middlewares/verifyAccesToken';
@@ -14,6 +17,7 @@ const adminItemsRouter = express.Router();
 
 const prisma = new PrismaClient();
 const itemRepository = new ItemRepository(prisma);
+const itemimageRepository = new ItemImageRepository(prisma);
 
 // 認証チェック
 adminItemsRouter.use(verifyAccessToken);
@@ -28,6 +32,10 @@ const updateItemController = new UpdateItemController(updateItemInteractor);
 const deleteItemInteractor = new DeleteItemInteractor(itemRepository);
 const deleteItemController = new DeleteItemController(deleteItemInteractor);
 
+const getItemImagesInteractor = new GetItemImagesInteractor(itemimageRepository);
+const getItemImagesController = new GetItemImagesController(getItemImagesInteractor);
+
+
 adminItemsRouter.post(
   '/',
   createItemController.execute.bind(createItemController),
@@ -41,6 +49,11 @@ adminItemsRouter.patch(
 adminItemsRouter.delete(
   '/:id',
   deleteItemController.execute.bind(deleteItemController),
+);
+
+adminItemsRouter.get(
+    '/:id/images',
+    getItemImagesController.execute.bind(getItemImagesController),
 );
 
 export { adminItemsRouter };

--- a/api/src/contexts/items/admin/interactors/GetItemImagesInteractor.ts
+++ b/api/src/contexts/items/admin/interactors/GetItemImagesInteractor.ts
@@ -1,0 +1,13 @@
+import { IGetItemImagesInteractor } from '../usecases/IGetItemImagesInteractor';
+import { IItemImageRepository } from '../../domains/repositories/IItemImageRepository';
+import { ItemImage } from '../../domains/entities/ItemImage';
+
+export class GetItemImagesInteractor implements IGetItemImagesInteractor {
+  constructor(private readonly itemimageRepository: IItemImageRepository) {}
+
+  async execute( itemId: number ): Promise<ItemImage[]> {
+
+    return await this.itemimageRepository.findbyItemId( itemId );
+    
+  }
+}

--- a/api/src/contexts/items/admin/usecases/IGetItemImagesInteractor.ts
+++ b/api/src/contexts/items/admin/usecases/IGetItemImagesInteractor.ts
@@ -1,0 +1,5 @@
+import { ItemImage } from '../../domains/entities/ItemImage';
+
+export interface IGetItemImagesInteractor {
+  execute( itemId: number ): Promise<ItemImage[]>;
+}

--- a/api/src/contexts/items/domains/entities/ItemImage.ts
+++ b/api/src/contexts/items/domains/entities/ItemImage.ts
@@ -1,0 +1,8 @@
+export type ItemImage = {
+    readonly id: number;
+    readonly itemId: number;
+    readonly src: string;
+    readonly order: number;
+    readonly createdAt: Date;
+    readonly updatedAt: Date;
+};

--- a/api/src/contexts/items/domains/repositories/IItemImageRepository.ts
+++ b/api/src/contexts/items/domains/repositories/IItemImageRepository.ts
@@ -1,0 +1,5 @@
+import { ItemImage } from '../entities/ItemImage';
+
+export interface IItemImageRepository {
+    findbyItemId(id: number): Promise<ItemImage[]>;
+}

--- a/api/src/contexts/items/infrastructures/repositories/ItemImageRepository.ts
+++ b/api/src/contexts/items/infrastructures/repositories/ItemImageRepository.ts
@@ -1,0 +1,16 @@
+import { PrismaClient } from '@prisma/client';
+import { IItemImageRepository } from '../../domains/repositories/IItemImageRepository';
+import { ItemImage } from '../../domains/entities/ItemImage';
+
+export class ItemImageRepository implements IItemImageRepository {
+    constructor(private readonly prisma: PrismaClient) {}
+
+    async findbyItemId(id: number): Promise<ItemImage[]> {
+        const itemImages = await this.prisma.itemImages.findMany({
+            where: { itemId: id },
+            orderBy: { order: 'asc' },
+        });
+
+        return itemImages;
+    }
+}

--- a/shared/schemas/itemimage.ts
+++ b/shared/schemas/itemimage.ts
@@ -1,0 +1,8 @@
+export type ItemImage = {
+    readonly id: number;
+    readonly itemId: number;
+    readonly src: string;
+    readonly order: number;
+    readonly createdAt: Date;
+    readonly updatedAt: Date;
+};

--- a/shared/types/gets.ts
+++ b/shared/types/gets.ts
@@ -1,7 +1,12 @@
 import { Item } from "@shared/schemas/item"
+import { ItemImage } from "@shared/schemas/itemimage"
 
 export type GetRes = {
     '/items': {
         items: Item[]
     }
+    '/items/:id/images': {
+        images: ItemImage[]
+    }
+
 }


### PR DESCRIPTION
### 概要
商品詳細の画像を取得するための新しい API エンドポイント `/items/:id/images` の追加

### 変更内容
- `ItemImage` エンティティと型定義を追加
- `IItemImageRepository` インターフェースと `ItemImageRepository` 実装を追加
- `IGetItemImagesInteractor` インターフェースと `GetItemImagesInteractor` を追加
- `GetItemImagesController` を追加
- 管理者用ルーター `adminItemsRouter` に GET `/items/:id/images` エンドポイントを追加
- Prisma を使用してアイテム画像を取得し、`order` 順に返却


### 補足
- IDが見つからない場合は400を返却
