### PR TITLE
APIレスポンスとフロントエンド側のUser型に値を追加

### DIFF
--- a/api/src/contexts/auth/interactors/LoginInteractor.ts
+++ b/api/src/contexts/auth/interactors/LoginInteractor.ts
@@ -41,6 +41,8 @@ export class LoginInteractor implements ILoginInteractor {
       token,
       user: {
         id: user.id,
+        lastName: user.lastName,
+        firstName: user.firstName,
         email: user.email,
         role: user.role,
       },

--- a/front/src/components/auth/AuthForm.tsx
+++ b/front/src/components/auth/AuthForm.tsx
@@ -33,6 +33,9 @@ export const AuthForm: React.FC<AuthFormProps> = ({
         if (response.user) {
           setUser({
             id: response.user.id,
+            lastName: response.user.lastName,
+            firstName: response.user.firstName,
+            email: response.user.email,
             role: response.user.role,
           });
         }

--- a/front/src/contexts/UserContext.tsx
+++ b/front/src/contexts/UserContext.tsx
@@ -9,6 +9,9 @@ import React, {
 
 export interface UserInfo {
   id: number | null;
+  lastName: string | null;
+  firstName: string | null;
+  email: string | null;
   role: 'USER' | 'ADMIN' | null;
 }
 
@@ -32,6 +35,9 @@ export const UserContextProvider: React.FC<UserContextProviderProps> = ({
 }) => {
   const [user, setUserState] = useState<UserInfo>({
     id: null,
+    lastName: null,
+    firstName: null,
+    email: null,
     role: null,
   });
 
@@ -40,11 +46,23 @@ export const UserContextProvider: React.FC<UserContextProviderProps> = ({
   }, []);
 
   const clearUser = useCallback(() => {
-    setUserState({ id: null, role: null });
+    setUserState({
+      id: null,
+      lastName: null,
+      firstName: null,
+      email: null,
+      role: null,
+    });
   }, []);
 
   const isLoggedIn = useCallback((): boolean => {
-    return user.id !== null && user.role !== null;
+    return (
+      user.id !== null &&
+      user.lastName !== null &&
+      user.firstName !== null &&
+      user.email !== null &&
+      user.role !== null
+    );
   }, [user]);
 
   const isAdmin = useCallback((): boolean => {

--- a/shared/schemas/user.ts
+++ b/shared/schemas/user.ts
@@ -1,5 +1,7 @@
 export type User = {
   id: number;
+    lastName: string;
+    firstName: string;
   email: string;
   role: 'USER' | 'ADMIN';
 };


### PR DESCRIPTION
/auth/meの実装の前段で、既存の型を修正しました。

/auth/meのレスポンスの値にid, lastname, firstname, email, roleを載せて、フロント側でそれらの値は常にグローバルに保存したいです。保存のタイミング的には、tokenが存在する状態でサイトを訪れた時と、ログイン時を想定しています。

そのため、既存のログインのレスポンスでもそれらの値を返すように修正し、フロント側のグローバルステートにも足りない値を追加しました。