### PR TITLE
/auth/meの実装

### DIFF
--- a/api/src/contexts/auth/controllers/meController.ts
+++ b/api/src/contexts/auth/controllers/meController.ts
@@ -1,0 +1,29 @@
+import express from 'express';
+import { GetRes } from '@shared/types/gets';
+import { IGetMeInteractor } from '../usecases/IGetMeInteractor';
+import { AuthenticatedRequest } from '../../../middlewares/verifyAccesToken';
+
+export class MeController {
+  constructor(private readonly getMeInteractor: IGetMeInteractor) {}
+
+  async execute(
+    req: AuthenticatedRequest,
+    res: express.Response<GetRes['/auth/me'] | { message: string }>,
+  ) {
+    if (!req.user) {
+      return res.status(401).json({ message: 'User not authenticated' });
+    }
+
+    const user = await this.getMeInteractor.execute(req.user.userId);
+
+    res.status(200).json({
+      user: {
+        id: user.id,
+        lastName: user.lastName,
+        firstName: user.firstName,
+        email: user.email,
+        role: user.role,
+      },
+    });
+  }
+}

--- a/api/src/contexts/auth/domains/repositories/IUserRepository.ts
+++ b/api/src/contexts/auth/domains/repositories/IUserRepository.ts
@@ -2,4 +2,5 @@ import { User } from '../entities/User';
 
 export interface IUserRepository {
   findByEmail(email: string): Promise<User | null>;
+  findById(id: number): Promise<User | null>;
 }

--- a/api/src/contexts/auth/index.ts
+++ b/api/src/contexts/auth/index.ts
@@ -1,9 +1,12 @@
 import { LoginController } from './controllers/LoginController';
 import { LogoutController } from './controllers/LogoutController';
+import { MeController } from './controllers/meController';
 import { LoginInteractor } from './interactors/LoginInteractor';
+import { GetMeInteractor } from './interactors/GetMeInteractor';
 import { UserRepository } from './infrastructures/repositories/UserRepository';
 import { prisma } from '../../libs/prisma';
 import express from 'express';
+import { verifyAccessToken } from '../../middlewares/verifyAccesToken';
 
 const authRouter = express.Router();
 
@@ -11,8 +14,15 @@ const userRepository = new UserRepository(prisma);
 const loginInteractor = new LoginInteractor(userRepository);
 const loginController = new LoginController(loginInteractor);
 const logoutController = new LogoutController();
+const getMeInteractor = new GetMeInteractor(userRepository);
+const meController = new MeController(getMeInteractor);
 
 authRouter.post('/login', loginController.execute.bind(loginController));
 authRouter.post('/logout', logoutController.execute.bind(logoutController));
+authRouter.get(
+  '/me',
+  verifyAccessToken,
+  meController.execute.bind(meController),
+);
 
 export { authRouter };

--- a/api/src/contexts/auth/infrastructures/repositories/UserRepository.ts
+++ b/api/src/contexts/auth/infrastructures/repositories/UserRepository.ts
@@ -26,4 +26,26 @@ export class UserRepository implements IUserRepository {
       updatedAt: user.updatedAt,
     };
   }
+
+  async findById(id: number): Promise<User | null> {
+    const user = await this.prisma.users.findUnique({
+      where: {
+        id,
+        isResigned: false,
+      },
+    });
+
+    if (!user) return null;
+
+    return {
+      id: user.id,
+      lastName: user.lastName,
+      firstName: user.firstName,
+      email: user.email,
+      password: user.password,
+      role: user.role,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    };
+  }
 }

--- a/api/src/contexts/auth/interactors/GetMeInteractor.ts
+++ b/api/src/contexts/auth/interactors/GetMeInteractor.ts
@@ -1,0 +1,26 @@
+import { IGetMeInteractor } from '../usecases/IGetMeInteractor';
+import { IUserRepository } from '../domains/repositories/IUserRepository';
+import { User } from '../domains/entities/User';
+
+export class GetMeInteractor implements IGetMeInteractor {
+  constructor(private readonly userRepository: IUserRepository) {}
+
+  async execute(userId: number): Promise<User> {
+    const user = await this.userRepository.findById(userId);
+
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    return {
+      id: user.id,
+      lastName: user.lastName,
+      firstName: user.firstName,
+      email: user.email,
+      password: user.password,
+      role: user.role,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    };
+  }
+}

--- a/api/src/contexts/auth/usecases/IGetMeInteractor.ts
+++ b/api/src/contexts/auth/usecases/IGetMeInteractor.ts
@@ -1,0 +1,5 @@
+import { User } from '../domains/entities/User';
+
+export interface IGetMeInteractor {
+  execute(userId: number): Promise<User>;
+}

--- a/front/src/contexts/UserContext.tsx
+++ b/front/src/contexts/UserContext.tsx
@@ -4,8 +4,10 @@ import React, {
   useState,
   useCallback,
   useMemo,
+  useEffect,
   ReactNode,
 } from 'react';
+import { AuthApiService } from '../services/api/auth';
 
 export interface UserInfo {
   id: number | null;
@@ -40,6 +42,27 @@ export const UserContextProvider: React.FC<UserContextProviderProps> = ({
     email: null,
     role: null,
   });
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const response = await AuthApiService.getMe();
+        if (response.user) {
+          setUserState({
+            id: response.user.id,
+            lastName: response.user.lastName,
+            firstName: response.user.firstName,
+            email: response.user.email,
+            role: response.user.role,
+          });
+        }
+      } catch (error) {
+        console.error('Failed to fetch user:', error);
+      }
+    };
+
+    fetchUser();
+  }, []);
 
   const setUser = useCallback((userInfo: UserInfo) => {
     setUserState(userInfo);

--- a/front/src/services/api/auth.ts
+++ b/front/src/services/api/auth.ts
@@ -1,5 +1,6 @@
 import { apiClient } from './apiClient';
 import { PostReq, PostRes } from '@shared/types/posts';
+import { GetRes } from '@shared/types/gets';
 
 export class AuthApiService {
   static async login(
@@ -15,5 +16,10 @@ export class AuthApiService {
 
   static async logout(): Promise<void> {
     await apiClient.post('/auth/logout', {});
+  }
+
+  static async getMe(): Promise<GetRes['/auth/me']> {
+    const response = await apiClient.get<GetRes['/auth/me']>('/auth/me');
+    return response.data;
   }
 }

--- a/shared/types/gets.ts
+++ b/shared/types/gets.ts
@@ -1,4 +1,5 @@
 import { Item } from "../schemas/item"
+import { User } from "../schemas/user"
 
 export type GetRes = {
     '/items': {
@@ -6,5 +7,8 @@ export type GetRes = {
     },
     '/admin/items': {
         items: Item[]
+    },
+    '/auth/me': {
+        user: User
     }
 }


### PR DESCRIPTION
#71
#46

auth/meエンドポイントの追加と呼び出し
サイト訪問時にcookieにtokenがあればユーザー情報をグローバルステートに保存する


[動作確認]
・ログイン状態でリロードしてもユーザーステートが保存されます
・ログアウト状態でリロードするとユーザー情報取得に失敗し401が返ってきます
↓


https://github.com/user-attachments/assets/ae3cf6fa-84fd-4c58-ba2e-56cd1f9aa216



※動画でログイン状態であることがわかりやすいように、コンソールログ出力と、ログイン中のみ「ログアウト」ボタンを表示するようにしていますが、その変更はコミットしていないです。