### PR TITLE
ホーム画面を削除して商品一覧を表示

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -17,7 +17,6 @@ import { AdminProductList } from './pages/admin/AdminProductList';
 import { AdminProductCreate } from './pages/admin/AdminProductCreate';
 import { AdminProductEdit } from './pages/admin/AdminProductEdit';
 import { AdminProductDelete } from './pages/admin/AdminProductDelete';
-import { UserProfileEdit } from './pages/user/UserProfileEdit';
 
 function App(): React.JSX.Element {
   return (
@@ -46,7 +45,6 @@ function App(): React.JSX.Element {
                 path="/admin/products/:id/delete"
                 element={<AdminProductDelete />}
               />
-              <Route path="/user/profile/edit" element={<UserProfileEdit />} />
             </Routes>
           </div>
         </div>

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Routes, Route, BrowserRouter } from 'react-router';
+import { Routes, Route, BrowserRouter, Navigate } from 'react-router';
 import './App.css';
 
 import { UserContextProvider } from './contexts/UserContext';
@@ -8,7 +8,6 @@ import { UserContextProvider } from './contexts/UserContext';
 import Header from './components/layout/Header';
 
 // ページ関係
-import { Home } from './pages/Home';
 import { ProductList } from './pages/ProductList';
 import { UserLogin } from './pages/auth/UserLogin';
 import { UserSignup } from './pages/auth/UserSignup';
@@ -18,6 +17,7 @@ import { AdminProductList } from './pages/admin/AdminProductList';
 import { AdminProductCreate } from './pages/admin/AdminProductCreate';
 import { AdminProductEdit } from './pages/admin/AdminProductEdit';
 import { AdminProductDelete } from './pages/admin/AdminProductDelete';
+import { UserProfileEdit } from './pages/user/UserProfileEdit';
 
 function App(): React.JSX.Element {
   return (
@@ -27,7 +27,7 @@ function App(): React.JSX.Element {
           <Header />
           <div className="container mx-auto p-4">
             <Routes>
-              <Route path="/" element={<Home />} />
+              <Route path="/" element={<Navigate to="/products" replace />} />
               <Route path="/products" element={<ProductList />} />
               <Route path="/auth/user/login" element={<UserLogin />} />
               <Route path="/auth/user/signup" element={<UserSignup />} />
@@ -46,6 +46,7 @@ function App(): React.JSX.Element {
                 path="/admin/products/:id/delete"
                 element={<AdminProductDelete />}
               />
+              <Route path="/user/profile/edit" element={<UserProfileEdit />} />
             </Routes>
           </div>
         </div>

--- a/front/src/components/layout/Header.tsx
+++ b/front/src/components/layout/Header.tsx
@@ -12,7 +12,6 @@ import {
 const Header: React.FC<HeaderProps> = ({
   logo = 'ECサイト',
   navigationItems = [
-    { label: 'ホーム', href: '/' },
     { label: '商品', href: '/products' },
     { label: 'ログイン', href: '/auth/user/login' },
     { label: '新規登録', href: '/auth/user/signup' },
@@ -24,7 +23,7 @@ const Header: React.FC<HeaderProps> = ({
         <div className="flex justify-between items-center">
           {/* ロゴ */}
           <div className="flex items-center">
-            <Link to="/">
+            <Link to="/products">
               <h1 className="text-xl font-bold text-gray-900">{logo}</h1>
             </Link>
           </div>

--- a/front/src/pages/Home.tsx
+++ b/front/src/pages/Home.tsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export const Home: React.FC = () => {
-  return <h1>HOME</h1>;
-};


### PR DESCRIPTION
#34 
## 内容

既存のHome画面はコンテンツを表示していなかったので、商品一覧をメインの画面にするように変更。
また、それに伴うヘッダーの「ホーム」の文言削除。