### PR TITLE
商品エンティティに在庫を追加

### DIFF
--- a/api/src/contexts/items/admin/controllers/DeleteItemController.ts
+++ b/api/src/contexts/items/admin/controllers/DeleteItemController.ts
@@ -19,22 +19,8 @@ export class DeleteItemController {
       return res.status(400).json({ message: 'Invalid item ID' });
     }
 
-    const item = await this.deleteItemInteractor.execute(itemId);
+    const result = await this.deleteItemInteractor.execute(itemId);
 
-    if (!item) {
-      return res.status(404).json({ message: 'Item not found' });
-    }
-
-    const responseItem = {
-      id: item.id,
-      name: item.name,
-      description: item.description,
-      type: item.type,
-      price: item.price,
-      createdAt: item.createdAt,
-      updatedAt: item.updatedAt,
-    };
-
-    res.status(200).json({ item: responseItem });
+    res.status(200).json({ deleted: result });
   }
 }

--- a/api/src/contexts/items/admin/interactors/DeleteItemInteractor.ts
+++ b/api/src/contexts/items/admin/interactors/DeleteItemInteractor.ts
@@ -1,11 +1,10 @@
 import { IDeleteItemInteractor } from '../usecases/IDeleteItemInteractor';
 import { IItemRepository } from '../../domains/repositories/IItemRepository';
-import { Item } from '../../domains/entities/Item';
 
 export class DeleteItemInteractor implements IDeleteItemInteractor {
   constructor(private readonly itemRepository: IItemRepository) {}
 
-  async execute(id: number): Promise<Item | null> {
+  async execute(id: number): Promise<boolean> {
     return await this.itemRepository.delete(id);
   }
 }

--- a/api/src/contexts/items/admin/usecases/IDeleteItemInteractor.ts
+++ b/api/src/contexts/items/admin/usecases/IDeleteItemInteractor.ts
@@ -1,5 +1,3 @@
-import { Item } from '../../domains/entities/Item';
-
 export interface IDeleteItemInteractor {
-  execute(id: number): Promise<Item | null>;
+  execute(id: number): Promise<boolean>;
 }

--- a/api/src/contexts/items/controllers/SearchItemsController.ts
+++ b/api/src/contexts/items/controllers/SearchItemsController.ts
@@ -1,0 +1,97 @@
+import express from 'express';
+import { GetRes } from '@shared/types/gets';
+import {
+  ISearchItemsInteractor,
+  SearchItemsParams,
+  SearchSortType,
+} from '../usecases/ISearchItemsInteractor';
+
+type SearchParamsResult =
+  | { success: true; params: SearchItemsParams }
+  | { success: false; error: string };
+
+export class SearchItemsController {
+  constructor(private readonly searchItemsInteractor: ISearchItemsInteractor) {}
+
+  async execute(
+    req: express.Request,
+    res: express.Response<GetRes['/items/search'] | { message: string }>,
+  ) {
+    const result = this.buildSearchParams(req.query);
+
+    if (!result.success) {
+      return res.status(400).json({ message: result.error });
+    }
+
+    const items = await this.searchItemsInteractor.execute(result.params);
+
+    const responseItems = items.map((item) => ({
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      type: item.type,
+      price: item.price,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    }));
+
+    res.status(200).json({ items: responseItems });
+  }
+
+  private buildSearchParams(
+    query: express.Request['query'],
+  ): SearchParamsResult {
+    const params: SearchItemsParams = {};
+
+    if (query.q) {
+      if (typeof query.q === 'string') {
+        params.q = query.q;
+      } else {
+        return { success: false, error: 'Invalid query parameter.' };
+      }
+    }
+
+    if (query.sort) {
+      if (this.isValidSortType(query.sort)) {
+        params.sort = query.sort;
+      } else {
+        return {
+          success: false,
+          error: `Invalid sort parameter.`,
+        };
+      }
+    }
+
+    if (query.page) {
+      const pageNum = this.parsePageNumber(query.page);
+      if (pageNum !== null && pageNum > 0) {
+        params.page = pageNum;
+      } else {
+        return {
+          success: false,
+          error: 'Invalid page parameter.',
+        };
+      }
+    }
+
+    return { success: true, params };
+  }
+
+  private isValidSortType(value: unknown): value is SearchSortType {
+    return (
+      typeof value === 'string' &&
+      Object.values(SearchSortType).includes(value as SearchSortType)
+    );
+  }
+
+  private parsePageNumber(value: unknown): number | null {
+    if (typeof value === 'number') {
+      return value;
+    }
+    if (typeof value === 'string') {
+      const parsed = parseInt(value, 10);
+      return isNaN(parsed) ? null : parsed;
+    }
+    return null;
+  }
+}

--- a/api/src/contexts/items/domains/entities/Item.ts
+++ b/api/src/contexts/items/domains/entities/Item.ts
@@ -4,6 +4,10 @@ export type Item = {
   readonly description: string;
   readonly type: number;
   readonly price: number;
+  readonly displayStatus: string;
+  readonly inventory: {
+    readonly amount: number;
+  };
   readonly createdAt: Date;
   readonly updatedAt: Date;
 };

--- a/api/src/contexts/items/domains/repositories/IItemRepository.ts
+++ b/api/src/contexts/items/domains/repositories/IItemRepository.ts
@@ -4,6 +4,7 @@ import { ItemQuery } from './ItemQuery';
 export interface IItemRepository {
   findAll(): Promise<Item[]>;
   find(query?: ItemQuery): Promise<Item[]>;
+  findById(id: number): Promise<Item | null>;
   create(name: string, description: string, type: number): Promise<Item>;
   update(
     id: number,

--- a/api/src/contexts/items/domains/repositories/IItemRepository.ts
+++ b/api/src/contexts/items/domains/repositories/IItemRepository.ts
@@ -1,7 +1,9 @@
 import { Item } from '../entities/Item';
+import { ItemQuery } from './ItemQuery';
 
 export interface IItemRepository {
   findAll(): Promise<Item[]>;
+  find(query?: ItemQuery): Promise<Item[]>;
   create(name: string, description: string, type: number): Promise<Item>;
   update(
     id: number,

--- a/api/src/contexts/items/domains/repositories/IItemRepository.ts
+++ b/api/src/contexts/items/domains/repositories/IItemRepository.ts
@@ -12,5 +12,5 @@ export interface IItemRepository {
     description?: string,
     type?: number,
   ): Promise<Item | null>;
-  delete(id: number): Promise<Item | null>;
+  delete(id: number): Promise<boolean>;
 }

--- a/api/src/contexts/items/domains/repositories/ItemQuery.ts
+++ b/api/src/contexts/items/domains/repositories/ItemQuery.ts
@@ -1,0 +1,13 @@
+export interface ItemQuery {
+  where?: {
+    name?: { contains?: string };
+    displayStatus?: { not?: string };
+  };
+  orderBy?: {
+    createdAt?: 'asc' | 'desc';
+    price?: 'asc' | 'desc';
+    name?: 'asc' | 'desc';
+  };
+  skip?: number;
+  take?: number;
+}

--- a/api/src/contexts/items/index.ts
+++ b/api/src/contexts/items/index.ts
@@ -1,5 +1,7 @@
 import { GetItemsController } from './controllers/GetItemsController';
 import { GetItemsInteractor } from './interactors/GetItemsInteractor';
+import { SearchItemsController } from './controllers/SearchItemsController';
+import { SearchItemsInteractor } from './interactors/SearchItemsInteractor';
 import { ItemRepository } from './infrastructures/repositories/ItemRepository';
 import { prisma } from '../../libs/prisma';
 import express from 'express';
@@ -9,7 +11,13 @@ const itemsRouter = express.Router();
 const itemRepository = new ItemRepository(prisma);
 const getItemsInteractor = new GetItemsInteractor(itemRepository);
 const getItemsController = new GetItemsController(getItemsInteractor);
+const searchItemsInteractor = new SearchItemsInteractor(itemRepository);
+const searchItemsController = new SearchItemsController(searchItemsInteractor);
 
 itemsRouter.get('/', getItemsController.execute.bind(getItemsController));
+itemsRouter.get(
+  '/search',
+  searchItemsController.execute.bind(searchItemsController),
+);
 
 export { itemsRouter };

--- a/api/src/contexts/items/infrastructures/repositories/ItemRepository.ts
+++ b/api/src/contexts/items/infrastructures/repositories/ItemRepository.ts
@@ -9,20 +9,44 @@ export class ItemRepository implements IItemRepository {
   async findAll(): Promise<Item[]> {
     const items = await this.prisma.items.findMany({
       orderBy: { createdAt: 'desc' },
+      include: {
+        Inventory: true,
+      },
     });
 
-    return items;
-  }
-
-  async find(query?: ItemQuery): Promise<Item[]> {
-    const prismaQuery = this.buildPrismaQuery(query);
-    const items = await this.prisma.items.findMany(prismaQuery);
     return items.map((item) => ({
       id: item.id,
       name: item.name,
       description: item.description,
       type: item.type,
       price: item.price,
+      displayStatus: item.displayStatus,
+      inventory: {
+        amount: item.Inventory?.[0]?.amount ?? 0,
+      },
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    }));
+  }
+
+  async find(query?: ItemQuery): Promise<Item[]> {
+    const prismaQuery = this.buildPrismaQuery(query);
+    const items = await this.prisma.items.findMany({
+      ...prismaQuery,
+      include: {
+        Inventory: true,
+      },
+    });
+    return items.map((item) => ({
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      type: item.type,
+      price: item.price,
+      displayStatus: item.displayStatus,
+      inventory: {
+        amount: item.Inventory?.[0]?.amount ?? 0,
+      },
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,
     }));
@@ -68,7 +92,19 @@ export class ItemRepository implements IItemRepository {
       },
     });
 
-    return item;
+    return {
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      type: item.type,
+      price: item.price,
+      displayStatus: item.displayStatus,
+      inventory: {
+        amount: 0,
+      },
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    };
   }
 
   async update(
@@ -98,7 +134,23 @@ export class ItemRepository implements IItemRepository {
       data: updateData,
     });
 
-    return item;
+    const inventory = await this.prisma.inventory.findFirst({
+      where: { itemId: item.id },
+    });
+
+    return {
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      type: item.type,
+      price: item.price,
+      displayStatus: item.displayStatus,
+      inventory: {
+        amount: inventory?.amount ?? 0,
+      },
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    };
   }
 
   async delete(id: number): Promise<Item | null> {
@@ -112,12 +164,43 @@ export class ItemRepository implements IItemRepository {
       where: { id },
     });
 
-    return item;
+    return {
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      type: item.type,
+      price: item.price,
+      displayStatus: item.displayStatus,
+      inventory: {
+        amount: 0,
+      },
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    };
   }
 
-  private async findById(id: number): Promise<Item | null> {
-    return await this.prisma.items.findUnique({
+  async findById(id: number): Promise<Item | null> {
+    const item = await this.prisma.items.findFirst({
       where: { id },
+      include: {
+        Inventory: true,
+      },
     });
+
+    return item
+      ? {
+          id: item.id,
+          name: item.name,
+          description: item.description,
+          type: item.type,
+          price: item.price,
+          displayStatus: item.displayStatus,
+          inventory: {
+            amount: item.Inventory?.[0]?.amount ?? 0,
+          },
+          createdAt: item.createdAt,
+          updatedAt: item.updatedAt,
+        }
+      : null;
   }
 }

--- a/api/src/contexts/items/infrastructures/repositories/ItemRepository.ts
+++ b/api/src/contexts/items/infrastructures/repositories/ItemRepository.ts
@@ -153,30 +153,18 @@ export class ItemRepository implements IItemRepository {
     };
   }
 
-  async delete(id: number): Promise<Item | null> {
+  async delete(id: number): Promise<boolean> {
     const existingItem = await this.findById(id);
 
     if (!existingItem) {
-      return null;
+      return false;
     }
 
-    const item = await this.prisma.items.delete({
+    await this.prisma.items.delete({
       where: { id },
     });
 
-    return {
-      id: item.id,
-      name: item.name,
-      description: item.description,
-      type: item.type,
-      price: item.price,
-      displayStatus: item.displayStatus,
-      inventory: {
-        amount: 0,
-      },
-      createdAt: item.createdAt,
-      updatedAt: item.updatedAt,
-    };
+    return true;
   }
 
   async findById(id: number): Promise<Item | null> {

--- a/api/src/contexts/items/infrastructures/repositories/ItemRepository.ts
+++ b/api/src/contexts/items/infrastructures/repositories/ItemRepository.ts
@@ -1,5 +1,6 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient, Prisma } from '@prisma/client';
 import { IItemRepository } from '../../domains/repositories/IItemRepository';
+import { ItemQuery } from '../../domains/repositories/ItemQuery';
 import { Item } from '../../domains/entities/Item';
 
 export class ItemRepository implements IItemRepository {
@@ -11,6 +12,51 @@ export class ItemRepository implements IItemRepository {
     });
 
     return items;
+  }
+
+  async find(query?: ItemQuery): Promise<Item[]> {
+    const prismaQuery = this.buildPrismaQuery(query);
+    const items = await this.prisma.items.findMany(prismaQuery);
+    return items.map((item) => ({
+      id: item.id,
+      name: item.name,
+      description: item.description,
+      type: item.type,
+      price: item.price,
+      createdAt: item.createdAt,
+      updatedAt: item.updatedAt,
+    }));
+  }
+
+  private buildPrismaQuery(query?: ItemQuery): Prisma.ItemsFindManyArgs {
+    const prismaQuery: Prisma.ItemsFindManyArgs = {};
+
+    if (query?.where) {
+      prismaQuery.where = {};
+      if (query.where.name?.contains) {
+        prismaQuery.where.name = {
+          contains: query.where.name.contains,
+        };
+      }
+      if (query.where.displayStatus?.not) {
+        prismaQuery.where.displayStatus = {
+          not: query.where.displayStatus.not,
+        };
+      }
+    }
+
+    if (query?.orderBy) {
+      prismaQuery.orderBy = query.orderBy;
+    }
+
+    if (query?.skip !== undefined) {
+      prismaQuery.skip = query.skip;
+    }
+    if (query?.take !== undefined) {
+      prismaQuery.take = query.take;
+    }
+
+    return prismaQuery;
   }
 
   async create(name: string, description: string, type: number): Promise<Item> {

--- a/api/src/contexts/items/interactors/SearchItemsInteractor.ts
+++ b/api/src/contexts/items/interactors/SearchItemsInteractor.ts
@@ -1,6 +1,7 @@
 import {
   ISearchItemsInteractor,
   SearchItemsParams,
+  SearchSortType,
 } from '../usecases/ISearchItemsInteractor';
 import { IItemRepository } from '../domains/repositories/IItemRepository';
 import { ItemQuery } from '../domains/repositories/ItemQuery';
@@ -35,19 +36,19 @@ export class SearchItemsInteractor implements ISearchItemsInteractor {
 
     // ソート条件
     switch (sort) {
-      case 'newest':
+      case SearchSortType.newest:
         query.orderBy = { createdAt: 'desc' };
         break;
-      case 'price_asc':
+      case SearchSortType.price_asc:
         query.orderBy = { price: 'asc' };
         break;
-      case 'price_desc':
+      case SearchSortType.price_desc:
         query.orderBy = { price: 'desc' };
         break;
-      case 'name_asc':
+      case SearchSortType.name_asc:
         query.orderBy = { name: 'asc' };
         break;
-      case 'name_desc':
+      case SearchSortType.name_desc:
         query.orderBy = { name: 'desc' };
         break;
       default:

--- a/api/src/contexts/items/interactors/SearchItemsInteractor.ts
+++ b/api/src/contexts/items/interactors/SearchItemsInteractor.ts
@@ -1,0 +1,63 @@
+import {
+  ISearchItemsInteractor,
+  SearchItemsParams,
+} from '../usecases/ISearchItemsInteractor';
+import { IItemRepository } from '../domains/repositories/IItemRepository';
+import { ItemQuery } from '../domains/repositories/ItemQuery';
+import { Item } from '../domains/entities/Item';
+
+export class SearchItemsInteractor implements ISearchItemsInteractor {
+  constructor(private readonly itemRepository: IItemRepository) {}
+
+  async execute(params: SearchItemsParams): Promise<Item[]> {
+    const query = this.buildQuery(params);
+    return await this.itemRepository.find(query);
+  }
+
+  private buildQuery(params: SearchItemsParams): ItemQuery {
+    const { q, sort = 'newest', page = 1 } = params;
+    const itemsPerPage = 20;
+    const skip = (page - 1) * itemsPerPage;
+
+    const query: ItemQuery = {
+      where: {
+        displayStatus: { not: 'private' },
+      },
+    };
+
+    // 検索条件
+    if (q) {
+      query.where = {
+        ...query.where,
+        name: { contains: q },
+      };
+    }
+
+    // ソート条件
+    switch (sort) {
+      case 'newest':
+        query.orderBy = { createdAt: 'desc' };
+        break;
+      case 'price_asc':
+        query.orderBy = { price: 'asc' };
+        break;
+      case 'price_desc':
+        query.orderBy = { price: 'desc' };
+        break;
+      case 'name_asc':
+        query.orderBy = { name: 'asc' };
+        break;
+      case 'name_desc':
+        query.orderBy = { name: 'desc' };
+        break;
+      default:
+        query.orderBy = { createdAt: 'desc' };
+    }
+
+    // ページネーション
+    query.skip = skip;
+    query.take = itemsPerPage;
+
+    return query;
+  }
+}

--- a/api/src/contexts/items/usecases/ISearchItemsInteractor.ts
+++ b/api/src/contexts/items/usecases/ISearchItemsInteractor.ts
@@ -1,0 +1,22 @@
+import { Item } from '../domains/entities/Item';
+
+export const SearchSortType = {
+  newest: 'newest',
+  price_asc: 'price_asc',
+  price_desc: 'price_desc',
+  name_asc: 'name_asc',
+  name_desc: 'name_desc',
+} as const;
+
+export type SearchSortType =
+  (typeof SearchSortType)[keyof typeof SearchSortType];
+
+export interface SearchItemsParams {
+  q?: string;
+  sort?: SearchSortType;
+  page?: number;
+}
+
+export interface ISearchItemsInteractor {
+  execute(params: SearchItemsParams): Promise<Item[]>;
+}

--- a/shared/types/delete.ts
+++ b/shared/types/delete.ts
@@ -1,9 +1,7 @@
-import { Item } from '../schemas/item';
-
 export type DeleteReq = {
   'admin/items/:id': Record<string, never>;
 };
 
 export type DeleteRes = {
-  'admin/items/:id': { item: Item };
+  'admin/items/:id': { deleted: boolean };
 };

--- a/shared/types/gets.ts
+++ b/shared/types/gets.ts
@@ -8,6 +8,9 @@ export type GetRes = {
   '/admin/items': {
     items: Item[];
   };
+  '/items/search': {
+    items: Item[];
+  };
   '/auth/me': {
     user: User;
   };


### PR DESCRIPTION
#31

商品詳細取得の実装前に商品エンティティに値を追加する修正だけ対応します。
ついでに商品削除APIのレスポンスも修正。