### PR TITLE
カート操作するAPIの実装

### DIFF
--- a/api/src/contexts/cart/controllers/CartController.ts
+++ b/api/src/contexts/cart/controllers/CartController.ts
@@ -7,14 +7,14 @@ export class CartController {
   constructor(private readonly cartInteractor: ICartInteractor) {}
 
   async execute(
-    req: AuthenticatedRequest,
+    req: AuthenticatedRequest<PostReq['/cart']>,
     res: express.Response<PostRes['/cart'] | { message: string }>,
   ) {
     if (!req.user) {
       return res.status(401).json({ message: 'User not authenticated' });
     }
 
-    const { items } = req.body as PostReq['/cart'];
+    const { items } = req.body;
 
     if (!Array.isArray(items)) {
       return res.status(400).json({ message: 'Items must be an array' });

--- a/api/src/contexts/cart/controllers/CartController.ts
+++ b/api/src/contexts/cart/controllers/CartController.ts
@@ -1,0 +1,38 @@
+import express from 'express';
+import { PostReq, PostRes } from '@shared/types/posts';
+import { ICartInteractor } from '../usecases/ICartInteractor';
+import { AuthenticatedRequest } from '../../../middlewares/verifyAccesToken';
+
+export class CartController {
+  constructor(private readonly cartInteractor: ICartInteractor) {}
+
+  async execute(
+    req: AuthenticatedRequest,
+    res: express.Response<PostRes['/cart'] | { message: string }>,
+  ) {
+    if (!req.user) {
+      return res.status(401).json({ message: 'User not authenticated' });
+    }
+
+    const { items } = req.body as PostReq['/cart'];
+
+    if (!Array.isArray(items)) {
+      return res.status(400).json({ message: 'Items must be an array' });
+    }
+
+    for (const item of items) {
+      if (typeof item.id !== 'number' || typeof item.amount !== 'number') {
+        return res
+          .status(400)
+          .json({ message: 'Each item must have id and amount as numbers' });
+      }
+      if (item.amount < 0) {
+        return res.status(400).json({ message: 'Amount must be non-negative' });
+      }
+    }
+
+    const cart = await this.cartInteractor.execute(req.user.userId, items);
+
+    res.status(200).json({ items: cart.items });
+  }
+}

--- a/api/src/contexts/cart/domains/entities/Cart.ts
+++ b/api/src/contexts/cart/domains/entities/Cart.ts
@@ -1,0 +1,12 @@
+export type Cart = {
+  readonly id: number;
+  readonly items: Array<{
+    readonly id: number;
+    readonly name: string;
+    readonly description: string;
+    readonly type: number;
+    readonly price: number;
+    readonly displayStatus: string;
+    readonly amount: number;
+  }>;
+};

--- a/api/src/contexts/cart/domains/repositories/ICartItemRepository.ts
+++ b/api/src/contexts/cart/domains/repositories/ICartItemRepository.ts
@@ -1,0 +1,3 @@
+export interface ICartItemRepository {
+  upsert(cartId: number, itemId: number, amount: number): Promise<void>;
+}

--- a/api/src/contexts/cart/domains/repositories/ICartRepository.ts
+++ b/api/src/contexts/cart/domains/repositories/ICartRepository.ts
@@ -1,0 +1,6 @@
+import { Cart } from '../entities/Cart';
+
+export interface ICartRepository {
+  find(userId: number): Promise<Cart | null>;
+  create(userId: number): Promise<Cart>;
+}

--- a/api/src/contexts/cart/index.ts
+++ b/api/src/contexts/cart/index.ts
@@ -1,0 +1,22 @@
+import { CartController } from './controllers/CartController';
+import { CartInteractor } from './interactors/CartInteractor';
+import { CartRepository } from './infrastructures/repositories/CartRepository';
+import { CartItemRepository } from './infrastructures/repositories/CartItemRepository';
+import { prisma } from '../../libs/prisma';
+import express from 'express';
+import { verifyAccessToken } from '../../middlewares';
+
+const cartRouter = express.Router();
+
+const cartRepository = new CartRepository(prisma);
+const cartItemRepository = new CartItemRepository(prisma);
+const cartInteractor = new CartInteractor(cartRepository, cartItemRepository);
+const cartController = new CartController(cartInteractor);
+
+cartRouter.post(
+  '/',
+  verifyAccessToken,
+  cartController.execute.bind(cartController),
+);
+
+export { cartRouter };

--- a/api/src/contexts/cart/index.ts
+++ b/api/src/contexts/cart/index.ts
@@ -2,6 +2,7 @@ import { CartController } from './controllers/CartController';
 import { CartInteractor } from './interactors/CartInteractor';
 import { CartRepository } from './infrastructures/repositories/CartRepository';
 import { CartItemRepository } from './infrastructures/repositories/CartItemRepository';
+import { ItemRepository } from '../items/infrastructures/repositories/ItemRepository';
 import { prisma } from '../../libs/prisma';
 import express from 'express';
 import { verifyAccessToken } from '../../middlewares';
@@ -10,7 +11,12 @@ const cartRouter = express.Router();
 
 const cartRepository = new CartRepository(prisma);
 const cartItemRepository = new CartItemRepository(prisma);
-const cartInteractor = new CartInteractor(cartRepository, cartItemRepository);
+const itemRepository = new ItemRepository(prisma);
+const cartInteractor = new CartInteractor(
+  cartRepository,
+  cartItemRepository,
+  itemRepository,
+);
 const cartController = new CartController(cartInteractor);
 
 cartRouter.post(

--- a/api/src/contexts/cart/infrastructures/repositories/CartItemRepository.ts
+++ b/api/src/contexts/cart/infrastructures/repositories/CartItemRepository.ts
@@ -1,0 +1,25 @@
+import { PrismaClient } from '@prisma/client';
+import { ICartItemRepository } from '../../domains/repositories/ICartItemRepository';
+
+export class CartItemRepository implements ICartItemRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async upsert(cartId: number, itemId: number, amount: number): Promise<void> {
+    await this.prisma.cartItems.upsert({
+      where: {
+        cartId_itemId: {
+          cartId,
+          itemId,
+        },
+      },
+      update: {
+        amount,
+      },
+      create: {
+        cartId,
+        itemId,
+        amount,
+      },
+    });
+  }
+}

--- a/api/src/contexts/cart/infrastructures/repositories/CartRepository.ts
+++ b/api/src/contexts/cart/infrastructures/repositories/CartRepository.ts
@@ -1,0 +1,68 @@
+import { PrismaClient } from '@prisma/client';
+import { ICartRepository } from '../../domains/repositories/ICartRepository';
+import { Cart } from '../../domains/entities/Cart';
+
+export class CartRepository implements ICartRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async find(userId: number): Promise<Cart | null> {
+    const cart = await this.prisma.cart.findUnique({
+      where: { userId },
+      include: {
+        cartItems: {
+          include: {
+            item: true,
+          },
+        },
+      },
+    });
+
+    return cart ? this.mapToCart(cart) : null;
+  }
+
+  async create(userId: number): Promise<Cart> {
+    const cart = await this.prisma.cart.create({
+      data: {
+        userId,
+      },
+      include: {
+        cartItems: {
+          include: {
+            item: true,
+          },
+        },
+      },
+    });
+
+    return this.mapToCart(cart);
+  }
+
+  private mapToCart(cart: {
+    id: number;
+    cartItems: Array<{
+      id: number;
+      amount: number;
+      item: {
+        id: number;
+        name: string;
+        description: string;
+        type: number;
+        price: number;
+        displayStatus: string;
+      };
+    }>;
+  }): Cart {
+    return {
+      id: cart.id,
+      items: cart.cartItems.map((cartItem) => ({
+        id: cartItem.item.id,
+        name: cartItem.item.name,
+        description: cartItem.item.description,
+        type: cartItem.item.type,
+        price: cartItem.item.price,
+        displayStatus: cartItem.item.displayStatus,
+        amount: cartItem.amount,
+      })),
+    };
+  }
+}

--- a/api/src/contexts/cart/interactors/CartInteractor.ts
+++ b/api/src/contexts/cart/interactors/CartInteractor.ts
@@ -1,18 +1,33 @@
 import { ICartInteractor } from '../usecases/ICartInteractor';
 import { ICartRepository } from '../domains/repositories/ICartRepository';
 import { ICartItemRepository } from '../domains/repositories/ICartItemRepository';
+import { IItemRepository } from '../../items/domains/repositories/IItemRepository';
 import { Cart } from '../domains/entities/Cart';
 
 export class CartInteractor implements ICartInteractor {
   constructor(
     private readonly cartRepository: ICartRepository,
     private readonly cartItemRepository: ICartItemRepository,
+    private readonly itemRepository: IItemRepository,
   ) {}
 
   async execute(
     userId: number,
     items: Array<{ id: number; amount: number }>,
   ): Promise<Cart> {
+    // 在庫チェック
+    for (const item of items) {
+      const product = await this.itemRepository.findById(item.id);
+      if (!product) {
+        throw new Error(`Item with id ${item.id} not found`);
+      }
+      if (product.inventory.amount < item.amount) {
+        throw new Error(
+          `Insufficient inventory for item ${product.name}. Available: ${product.inventory.amount}, Requested: ${item.amount}`,
+        );
+      }
+    }
+
     const cart =
       (await this.cartRepository.find(userId)) ??
       (await this.cartRepository.create(userId));

--- a/api/src/contexts/cart/interactors/CartInteractor.ts
+++ b/api/src/contexts/cart/interactors/CartInteractor.ts
@@ -1,0 +1,31 @@
+import { ICartInteractor } from '../usecases/ICartInteractor';
+import { ICartRepository } from '../domains/repositories/ICartRepository';
+import { ICartItemRepository } from '../domains/repositories/ICartItemRepository';
+import { Cart } from '../domains/entities/Cart';
+
+export class CartInteractor implements ICartInteractor {
+  constructor(
+    private readonly cartRepository: ICartRepository,
+    private readonly cartItemRepository: ICartItemRepository,
+  ) {}
+
+  async execute(
+    userId: number,
+    items: Array<{ id: number; amount: number }>,
+  ): Promise<Cart> {
+    const cart =
+      (await this.cartRepository.find(userId)) ??
+      (await this.cartRepository.create(userId));
+
+    for (const item of items) {
+      await this.cartItemRepository.upsert(cart.id, item.id, item.amount);
+    }
+
+    const updatedCart = await this.cartRepository.find(userId);
+    if (!updatedCart) {
+      throw new Error('Cart not found after update');
+    }
+
+    return updatedCart;
+  }
+}

--- a/api/src/contexts/cart/usecases/ICartInteractor.ts
+++ b/api/src/contexts/cart/usecases/ICartInteractor.ts
@@ -1,0 +1,8 @@
+import { Cart } from '../domains/entities/Cart';
+
+export interface ICartInteractor {
+  execute(
+    userId: number,
+    items: Array<{ id: number; amount: number }>,
+  ): Promise<Cart>;
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -11,6 +11,7 @@ import { adminItemsRouter } from './contexts/items/admin';
 import { authRouter } from './contexts/auth';
 import { prisma } from './libs/prisma';
 import { UsersRouter as usersRouter } from './contexts/users';
+import { cartRouter } from './contexts/cart';
 
 const app = express();
 
@@ -33,6 +34,7 @@ app.use('/items', itemsRouter);
 app.use('/admin/items', adminItemsRouter);
 
 app.use('/users', usersRouter);
+app.use('/cart', cartRouter);
 
 app.listen(8000, '0.0.0.0', () => {
   // eslint-disable-next-line no-console

--- a/api/src/middlewares/verifyAccesToken.ts
+++ b/api/src/middlewares/verifyAccesToken.ts
@@ -2,7 +2,11 @@ import express from 'express';
 import { verifyJWT, JWTPayload } from '../utils/jwt';
 import { IVerifyUserInteractor } from '../contexts/auth/usecases/IVerifyUserInteractor';
 
-export interface AuthenticatedRequest extends express.Request {
+export interface AuthenticatedRequest<
+  ReqBody = any,
+  PathParams = any,
+  ReqQuery = any,
+> extends express.Request<PathParams, any, ReqBody, ReqQuery> {
   user?: JWTPayload;
 }
 

--- a/shared/types/posts.ts
+++ b/shared/types/posts.ts
@@ -17,6 +17,12 @@ export type PostReq = {
     email: string;
     password: string;
   };
+  '/cart': {
+    items: {
+      id: number;
+      amount: number;
+    }[];
+  };
 };
 
 export type PostRes = {
@@ -28,5 +34,16 @@ export type PostRes = {
   };
   'users/signup': {
     createdUser: User;
+  };
+  '/cart': {
+    items: Array<{
+      id: number;
+      name: string;
+      description: string;
+      type: number;
+      price: number;
+      displayStatus: string;
+      amount: number;
+    }>;
   };
 };


### PR DESCRIPTION
#96

在庫数を編集するAPIを作成しました。エンドポイントは`POST   /cart/items  `です。
リクエストパラメータは更新後の在庫数を送ります。現在の在庫数に対する差分を送る形式も検討しましたが、それだとAPIの[冪等性](https://zenn.dev/hirohiroeng/articles/07df29fdc226a6)がないのでやめました。