### PR TITLE
カート取得時にゲストカートと会員カートをマージする

### DIFF
--- a/api/src/contexts/cart/controllers/GetCartController.ts
+++ b/api/src/contexts/cart/controllers/GetCartController.ts
@@ -1,11 +1,20 @@
 import express from 'express';
 import { GetRes } from '@shared/types/gets';
 import { IGetCartInteractor } from '../usecases/IGetCartInteractor';
+import { IMergeCartInteractor } from '../usecases/IMergeCartInteractor';
+import { ICartRepository } from '../domains/repositories/ICartRepository';
 import { AuthenticatedRequest } from '../../../middlewares/verifyAccessToken';
-import { getCartSessionIdFromCookie } from '../../../utils/cookie';
+import {
+  getCartSessionIdFromCookie,
+  clearCartSessionIdCookie,
+} from '../../../utils/cookie';
 
 export class GetCartController {
-  constructor(private readonly getCartInteractor: IGetCartInteractor) {}
+  constructor(
+    private readonly getCartInteractor: IGetCartInteractor,
+    private readonly mergeCartInteractor: IMergeCartInteractor,
+    private readonly cartRepository: ICartRepository,
+  ) {}
 
   async execute(
     req: AuthenticatedRequest,
@@ -15,11 +24,43 @@ export class GetCartController {
       let cart;
 
       if (req.user) {
-        cart = await this.getCartInteractor.execute(
-          Number(req.user.userId),
-          undefined,
-        );
+        const sessionId = getCartSessionIdFromCookie(req);
+
+        if (sessionId) {
+          // CookieにsessionIdがある場合: マージ処理
+          const sessionCart = await this.getCartInteractor.execute(
+            undefined,
+            sessionId,
+          );
+
+          if (sessionCart && sessionCart.items.length > 0) {
+            // セッションカートとユーザーカートをマージ
+            cart = await this.mergeCartInteractor.execute(
+              req.user.userId,
+              sessionCart,
+            );
+
+            // マージ後、sessionカートを削除
+            await this.cartRepository.deleteBySessionId(sessionId);
+
+            // sessionIdをCookieから削除
+            clearCartSessionIdCookie(res);
+          } else {
+            // セッションカートが空の場合はユーザーカートを取得
+            cart = await this.getCartInteractor.execute(
+              Number(req.user.userId),
+              undefined,
+            );
+          }
+        } else {
+          // CookieにsessionIdがない場合: ユーザーカートを取得
+          cart = await this.getCartInteractor.execute(
+            Number(req.user.userId),
+            undefined,
+          );
+        }
       } else {
+        // ゲストユーザーの場合: CookieのsessionIdを使用
         const sessionId = getCartSessionIdFromCookie(req);
 
         if (sessionId) {

--- a/api/src/contexts/cart/controllers/PostCartController.ts
+++ b/api/src/contexts/cart/controllers/PostCartController.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { PostReq, PostRes } from '@shared/types/posts';
-import { ICartInteractor } from '../usecases/ICartInteractor';
+import { IUpdateCartInteractor } from '../usecases/IUpdateCartInteractor';
 import { IGetCartInteractor } from '../usecases/IGetCartInteractor';
 import { IMergeCartInteractor } from '../usecases/IMergeCartInteractor';
 import { ICartRepository } from '../domains/repositories/ICartRepository';
@@ -14,7 +14,7 @@ import { generateSessionId } from '../../../utils/sessionId';
 
 export class PostCartController {
   constructor(
-    private readonly cartInteractor: ICartInteractor,
+    private readonly updateCartInteractor: IUpdateCartInteractor,
     private readonly getCartInteractor: IGetCartInteractor,
     private readonly mergeCartInteractor: IMergeCartInteractor,
     private readonly cartRepository: ICartRepository,
@@ -67,14 +67,14 @@ export class PostCartController {
             clearCartSessionIdCookie(res);
 
             // マージ後にリクエストされたitemsも追加
-            cart = await this.cartInteractor.execute(
+            cart = await this.updateCartInteractor.execute(
               req.user.userId,
               undefined,
               items,
             );
           } else {
             // セッションカートが空の場合は通常のカート操作
-            cart = await this.cartInteractor.execute(
+            cart = await this.updateCartInteractor.execute(
               req.user.userId,
               undefined,
               items,
@@ -82,7 +82,7 @@ export class PostCartController {
           }
         } else {
           // CookieにsessionIdがない場合: 通常のカート操作
-          cart = await this.cartInteractor.execute(
+          cart = await this.updateCartInteractor.execute(
             req.user.userId,
             undefined,
             items,
@@ -98,7 +98,11 @@ export class PostCartController {
           setCartSessionIdCookie(res, sessionId);
         }
 
-        cart = await this.cartInteractor.execute(undefined, sessionId, items);
+        cart = await this.updateCartInteractor.execute(
+          undefined,
+          sessionId,
+          items,
+        );
       }
 
       res.status(200).json({ items: cart.items });

--- a/api/src/contexts/cart/index.ts
+++ b/api/src/contexts/cart/index.ts
@@ -1,5 +1,5 @@
 import { PostCartController } from './controllers/PostCartController';
-import { CartInteractor } from './interactors/CartInteractor';
+import { UpdateCartInteractor } from './interactors/UpdateCartInteractor';
 import { GetCartController } from './controllers/GetCartController';
 import { GetCartInteractor } from './interactors/GetCartInteractor';
 import { MergeCartInteractor } from './interactors/MergeCartInteractor';
@@ -15,7 +15,7 @@ const cartRouter = express.Router();
 const cartRepository = new CartRepository(prisma);
 const cartItemRepository = new CartItemRepository(prisma);
 const itemRepository = new ItemRepository(prisma);
-const cartInteractor = new CartInteractor(
+const updateCartInteractor = new UpdateCartInteractor(
   cartRepository,
   cartItemRepository,
   itemRepository,
@@ -26,13 +26,17 @@ const mergeCartInteractor = new MergeCartInteractor(
   cartItemRepository,
 );
 const cartController = new PostCartController(
-  cartInteractor,
+  updateCartInteractor,
   getCartInteractor,
   mergeCartInteractor,
   cartRepository,
 );
 
-const getCartController = new GetCartController(getCartInteractor);
+const getCartController = new GetCartController(
+  getCartInteractor,
+  mergeCartInteractor,
+  cartRepository,
+);
 
 cartRouter.get(
   '/',

--- a/api/src/contexts/cart/interactors/UpdateCartInteractor.ts
+++ b/api/src/contexts/cart/interactors/UpdateCartInteractor.ts
@@ -1,10 +1,10 @@
-import { ICartInteractor } from '../usecases/ICartInteractor';
+import { IUpdateCartInteractor } from '../usecases/IUpdateCartInteractor';
 import { ICartRepository } from '../domains/repositories/ICartRepository';
 import { ICartItemRepository } from '../domains/repositories/ICartItemRepository';
 import { IItemRepository } from '../../items/domains/repositories/IItemRepository';
 import { Cart } from '../domains/entities/Cart';
 
-export class CartInteractor implements ICartInteractor {
+export class UpdateCartInteractor implements IUpdateCartInteractor {
   constructor(
     private readonly cartRepository: ICartRepository,
     private readonly cartItemRepository: ICartItemRepository,

--- a/api/src/contexts/cart/usecases/IUpdateCartInteractor.ts
+++ b/api/src/contexts/cart/usecases/IUpdateCartInteractor.ts
@@ -1,6 +1,6 @@
 import { Cart } from '../domains/entities/Cart';
 
-export interface ICartInteractor {
+export interface IUpdateCartInteractor {
   execute(
     userId: number | undefined,
     sessionId: string | undefined,


### PR DESCRIPTION
#116 

ゲスト状態でカートにアイテム追加
↓
途中でログイン
↓
カート画面に遷移

した時にゲスト用のカートと登録ユーザー用のカートの中身を統合する処理を追加しました