### PR TITLE
商品数が0ならCartItemのレコードを削除する

### DIFF
--- a/api/src/contexts/cart/domains/repositories/ICartItemRepository.ts
+++ b/api/src/contexts/cart/domains/repositories/ICartItemRepository.ts
@@ -1,3 +1,4 @@
 export interface ICartItemRepository {
   upsert(cartId: number, itemId: number, amount: number): Promise<void>;
+  delete(cartId: number, itemId: number): Promise<void>;
 }

--- a/api/src/contexts/cart/infrastructures/repositories/CartItemRepository.ts
+++ b/api/src/contexts/cart/infrastructures/repositories/CartItemRepository.ts
@@ -22,4 +22,15 @@ export class CartItemRepository implements ICartItemRepository {
       },
     });
   }
+
+  async delete(cartId: number, itemId: number): Promise<void> {
+    await this.prisma.cartItems.delete({
+      where: {
+        cartId_itemId: {
+          cartId,
+          itemId,
+        },
+      },
+    });
+  }
 }

--- a/api/src/contexts/cart/interactors/UpdateCartInteractor.ts
+++ b/api/src/contexts/cart/interactors/UpdateCartInteractor.ts
@@ -16,23 +16,30 @@ export class UpdateCartInteractor implements IUpdateCartInteractor {
     sessionId: string | undefined,
     items: Array<{ id: number; amount: number }>,
   ): Promise<Cart> {
-    // 在庫チェック
+    // 在庫チェック（amount > 0の場合のみ）
     for (const item of items) {
-      const product = await this.itemRepository.findById(item.id);
-      if (!product) {
-        throw new Error(`Item with id ${item.id} not found`);
-      }
-      if (product.inventory.amount < item.amount) {
-        throw new Error(
-          `Insufficient inventory for item ${product.name}. Available: ${product.inventory.amount}, Requested: ${item.amount}`,
-        );
+      if (item.amount > 0) {
+        const product = await this.itemRepository.findById(item.id);
+        if (!product) {
+          throw new Error(`Item with id ${item.id} not found`);
+        }
+        if (product.inventory.amount < item.amount) {
+          throw new Error(
+            `Insufficient inventory for item ${product.name}. Available: ${product.inventory.amount}, Requested: ${item.amount}`,
+          );
+        }
       }
     }
 
     const cart = await this.getOrCreateCart(userId, sessionId);
 
     for (const item of items) {
-      await this.cartItemRepository.upsert(cart.id, item.id, item.amount);
+      console.log(item);
+      if (item.amount === 0) {
+        await this.cartItemRepository.delete(cart.id, item.id);
+      } else {
+        await this.cartItemRepository.upsert(cart.id, item.id, item.amount);
+      }
     }
 
     const updatedCart = await this.cartRepository.findById(cart.id);


### PR DESCRIPTION
#135 

APIを直接叩いて動作確認済み

こんな感じで送るとCartItemsからid=1の商品が削除されます。
```
{
  "items": [
    {
      "id": 1,
      "amount": 0
    }
  ]
}
```