### PR TITLE
GitHub Actionsでapitestを実行する

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -46,7 +46,12 @@ jobs:
           cache: "npm"
           cache-dependency-path: api/package-lock.json
 
-      - name: Install dependencies
+      - name: Install root dependencies (skip husky)
+        env:
+          CI: true
+        run: npm ci --ignore-scripts || true
+
+      - name: Install API dependencies
         working-directory: ./api
         run: npm ci
 

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -50,8 +50,10 @@ jobs:
         env:
           CI: true
           HUSKY: 0
+          npm_config_ignore_scripts: true
         run: |
-          npm ci --ignore-scripts || true
+          # workspaceの設定により、apiディレクトリでnpm ciを実行するとルートのprepareが実行される可能性があるため、
+          # npm_config_ignore_scripts環境変数で全てのスクリプトを無効化
           cd api && npm ci
 
       - name: Generate Prisma Client

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -7,7 +7,8 @@ on:
       - "api/**"
       - ".github/workflows/api-test.yml"
   pull_request:
-    branches: [main, develop]
+    # 一時的にすべてのPRで実行（動作確認用）
+    # TODO: 動作確認後、branches: [main, develop] に戻す
     paths:
       - "api/**"
       - ".github/workflows/api-test.yml"

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -1,0 +1,76 @@
+name: API Tests
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - "api/**"
+      - ".github/workflows/api-test.yml"
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - "api/**"
+      - ".github/workflows/api-test.yml"
+  workflow_dispatch: # 手動実行を有効化
+
+jobs:
+  test:
+    name: Run API Tests
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: ecommerce_test
+          MYSQL_USER: test_user
+          MYSQL_PASSWORD: test_password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost -ppassword"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: api/package-lock.json
+
+      - name: Install dependencies
+        working-directory: ./api
+        run: npm ci
+
+      - name: Generate Prisma Client
+        working-directory: ./api
+        run: npx prisma generate
+
+      - name: Create .env.test file
+        working-directory: ./api
+        run: |
+          echo 'DATABASE_URL="mysql://test_user:test_password@localhost:3306/ecommerce_test"' > .env.test
+          echo 'NODE_ENV=test' >> .env.test
+
+      - name: Run database migrations
+        working-directory: ./api
+        run: npm run migrate:test
+
+      - name: Run API tests
+        working-directory: ./api
+        run: npm run test:api
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: api/coverage/
+          if-no-files-found: ignore

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -46,14 +46,13 @@ jobs:
           cache: "npm"
           cache-dependency-path: api/package-lock.json
 
-      - name: Install root dependencies (skip husky)
+      - name: Install dependencies
         env:
           CI: true
-        run: npm ci --ignore-scripts || true
-
-      - name: Install API dependencies
-        working-directory: ./api
-        run: npm ci
+          HUSKY: 0
+        run: |
+          npm ci --ignore-scripts || true
+          cd api && npm ci
 
       - name: Generate Prisma Client
         working-directory: ./api

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -7,8 +7,9 @@ on:
       - "api/**"
       - ".github/workflows/api-test.yml"
   pull_request:
-    # 一時的にすべてのPRで実行（動作確認用）
-    # TODO: 動作確認後、branches: [main, develop] に戻す
+    branches:
+      - main
+      - develop
     paths:
       - "api/**"
       - ".github/workflows/api-test.yml"


### PR DESCRIPTION
developかmainブランチをベースブランチとしたPRを作成した時に自動で実行されます。api側に修正がある時のみ実行されるはずです。

コアなAPIについてはapitestを書くつもりなので、apitestの自動実行で大事な機能がデグレしてないことを担保できるようになるイメージです。

ブランチ保護設定をGitHub上でやればapitestが通らないとマージできないようにもできそうですが、僕は権限がないのでできなかったです。 @KaichiOnodera さんなら多分できるかな。もしできそうだったら一回設定してみて欲しいです。