### PR TITLE
stripeゲスト対応と住所情報に関する設定変更

### DIFF
--- a/api/src/contexts/checkout/domains/adapters/IStripeAdapter.ts
+++ b/api/src/contexts/checkout/domains/adapters/IStripeAdapter.ts
@@ -21,6 +21,8 @@ export interface IStripeAdapter {
     successUrl: string;
     cancelUrl: string;
     customerEmail?: string;
+    requireEmail?: boolean;
+    requireShippingAddress?: boolean;
     metadata?: Record<string, string>;
   }): Promise<CheckoutSession>;
 }

--- a/api/src/contexts/checkout/index.ts
+++ b/api/src/contexts/checkout/index.ts
@@ -4,6 +4,7 @@ import { StripeAdapter } from './infrastructures/adapters/StripeAdapter';
 import { CartRepository } from '../cart/infrastructures/repositories/CartRepository';
 import { ItemRepository } from '../items/infrastructures/repositories/ItemRepository';
 import { UserRepository } from '../users/infrastructures/repositories/UserRepository';
+import { OrderRepository } from '../orders/infrastructures/repositories/OrderRepository';
 import { prisma } from '../../libs/prisma';
 import express from 'express';
 import { verifyAccessToken } from '../../middlewares';
@@ -13,6 +14,7 @@ const checkoutRouter = express.Router();
 const cartRepository = new CartRepository(prisma);
 const itemRepository = new ItemRepository(prisma);
 const userRepository = new UserRepository(prisma);
+const orderRepository = new OrderRepository(prisma);
 const stripeAdapter = new StripeAdapter();
 
 const createCheckoutSessionInteractor = new CreateCheckoutSessionInteractor(
@@ -20,6 +22,7 @@ const createCheckoutSessionInteractor = new CreateCheckoutSessionInteractor(
   itemRepository,
   userRepository,
   stripeAdapter,
+  orderRepository,
 );
 
 const createCheckoutSessionController = new CreateCheckoutSessionController(

--- a/api/src/contexts/checkout/infrastructures/adapters/StripeAdapter.ts
+++ b/api/src/contexts/checkout/infrastructures/adapters/StripeAdapter.ts
@@ -34,6 +34,8 @@ export class StripeAdapter implements IStripeAdapter {
     successUrl: string;
     cancelUrl: string;
     customerEmail?: string;
+    requireEmail?: boolean;
+    requireShippingAddress?: boolean;
     metadata?: Record<string, string>;
   }): Promise<CheckoutSession> {
     const sessionParams: Stripe.Checkout.SessionCreateParams = {
@@ -55,8 +57,19 @@ export class StripeAdapter implements IStripeAdapter {
       metadata: params.metadata,
     };
 
+    // メールアドレスの処理
+    // ログインユーザーの場合：既知のメールアドレスを設定
+    // ゲストユーザーの場合：customer_emailを設定しないことでStripeが自動的にメールアドレスを収集
     if (params.customerEmail) {
       sessionParams.customer_email = params.customerEmail;
+    }
+    // customerEmailがない場合（ゲストユーザー）、Stripeが自動的にメールアドレス収集フォームを表示します
+
+    // 物理商品がある場合、住所入力を必須にする
+    if (params.requireShippingAddress) {
+      sessionParams.shipping_address_collection = {
+        allowed_countries: ['JP'],
+      };
     }
 
     const session = await this.stripe.checkout.sessions.create(sessionParams);

--- a/api/src/contexts/checkout/interactors/CreateCheckoutSessionInteractor.ts
+++ b/api/src/contexts/checkout/interactors/CreateCheckoutSessionInteractor.ts
@@ -108,6 +108,13 @@ export class CreateCheckoutSessionInteractor
       },
     });
 
+    // StripeセッションIDを保存
+    await this.orderRepository.createPaymentExternalId({
+      orderId: order.id,
+      provider: 'STRIPE',
+      paymentSessionId: session.sessionId,
+    });
+
     return {
       sessionId: session.sessionId,
       url: session.checkoutUrl,

--- a/api/src/contexts/checkout/interactors/CreateCheckoutSessionInteractor.ts
+++ b/api/src/contexts/checkout/interactors/CreateCheckoutSessionInteractor.ts
@@ -3,7 +3,9 @@ import { ICartRepository } from '../../cart/domains/repositories/ICartRepository
 import { IItemRepository } from '../../items/domains/repositories/IItemRepository';
 import { IUserRepository } from '../../users/domains/repositories/IUserRepository';
 import { IStripeAdapter } from '../domains/adapters/IStripeAdapter';
+import { IOrderRepository } from '../../orders/domains/repositories/IOrderRepository';
 import { CheckoutSessionMode } from '../domains/entities/CheckoutSession';
+import { OrderStatus } from '@prisma/client';
 
 export class CreateCheckoutSessionInteractor
   implements ICreateCheckoutSessionInteractor
@@ -13,6 +15,7 @@ export class CreateCheckoutSessionInteractor
     private readonly itemRepository: IItemRepository,
     private readonly userRepository: IUserRepository,
     private readonly stripeAdapter: IStripeAdapter,
+    private readonly orderRepository: IOrderRepository,
   ) {}
 
   async execute(params: {
@@ -35,6 +38,12 @@ export class CreateCheckoutSessionInteractor
       process.env.CHECKOUT_CANCEL_URL ?? 'http://localhost:3000/products';
 
     const lineItems = [];
+    let hasPhysicalProduct = false;
+    const totalPrice = cart.items.reduce(
+      (sum, item) => sum + item.price * item.amount,
+      0,
+    );
+
     for (const cartItem of cart.items) {
       const item = await this.itemRepository.findById(cartItem.id);
       if (!item) {
@@ -46,6 +55,11 @@ export class CreateCheckoutSessionInteractor
         throw new Error(
           `Insufficient inventory for item ${item.name}. Available: ${item.inventory.amount}, Requested: ${cartItem.amount}`,
         );
+      }
+
+      // 物理商品かチェック
+      if (item.type === 1) {
+        hasPhysicalProduct = true;
       }
 
       // Stripe用のlineItemsを作成
@@ -62,16 +76,35 @@ export class CreateCheckoutSessionInteractor
       });
     }
 
+    // Orderの作成
+    const order = await this.orderRepository.create({
+      userId: params.userId,
+      lastName: user.lastName,
+      firstName: user.firstName,
+      email: user.email,
+      address: '', // 後でWebhookで更新: checkoutページでアドレスを入力する
+      totalPrice,
+      orderStatus: OrderStatus.PENDING,
+      orderItems: cart.items.map((cartItem) => ({
+        itemId: cartItem.id,
+        itemName: cartItem.name,
+        itemPrice: cartItem.price,
+        amount: cartItem.amount,
+      })),
+    });
+
     // Stripe Checkout Session作成
     const session = await this.stripeAdapter.createCheckoutSession({
       lineItems,
       mode: CheckoutSessionMode.Payment,
       successUrl,
       cancelUrl,
-      customerEmail: user.email,
+      customerEmail: user.email, // ログインユーザーのメールアドレスを設定
+      requireShippingAddress: hasPhysicalProduct, // 物理商品がある場合のみ住所入力を必須にする
       metadata: {
         userId: params.userId.toString(),
         cartId: cart.id.toString(),
+        orderId: order.id.toString(),
       },
     });
 


### PR DESCRIPTION
#123
#137

## 内容
ゲストは、メールアドレスをcheckout ページで入力させるように変更。
物理商品がある場合は、住所の入力を必須にする。

## 画面

<img width="1911" height="943" alt="image" src="https://github.com/user-attachments/assets/ffbda917-b3e3-40aa-a0b4-09fbf59430d7" />

住所入力が必須フィールドになることを確認。
<img width="546" height="760" alt="image" src="https://github.com/user-attachments/assets/ef100fe9-b628-44e8-865b-9ddfa476b8d1" />


## 備考
- ゲスト側でのメールドレス入力必須になるか確認とれていません。
- デジタル商品のみの時に、アドレスが必須になるか確認とれていません。

↑ 上記、フロント側が今認証ないと、ログイン画面に飛ぶようになっているので、その修正して確認します。

また、以下のPRがマージされたら、sessionIDを保存する処理を追加します。
https://github.com/KaichiOnodera/recursion-ecommerce-app/pull/169