### PR TITLE
VerificationTokenテーブルの作成、EmailVerifiiedフィールドの追加

### DIFF
--- a/api/prisma/migrations/20251223112444_create_verification_token_table/migration.sql
+++ b/api/prisma/migrations/20251223112444_create_verification_token_table/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE `VerificationToken` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `token` VARCHAR(191) NOT NULL,
+    `userId` INTEGER NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `VerificationToken_token_key`(`token`),
+    UNIQUE INDEX `VerificationToken_userId_key`(`userId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `VerificationToken` ADD CONSTRAINT `VerificationToken_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `Users`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/migrations/20251223113025_add_email_verified/migration.sql
+++ b/api/prisma/migrations/20251223113025_add_email_verified/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `Users` ADD COLUMN `emailVerified` BOOLEAN NOT NULL DEFAULT false;

--- a/api/prisma/migrations/20251226154143_fix_email_verification_token/migration.sql
+++ b/api/prisma/migrations/20251226154143_fix_email_verification_token/migration.sql
@@ -1,0 +1,27 @@
+/*
+  Warnings:
+
+  - You are about to drop the `VerificationToken` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE `VerificationToken` DROP FOREIGN KEY `VerificationToken_userId_fkey`;
+
+-- DropTable
+DROP TABLE `VerificationToken`;
+
+-- CreateTable
+CREATE TABLE `EmailVerificationToken` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `token` VARCHAR(191) NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `EmailVerificationToken_token_key`(`token`),
+    UNIQUE INDEX `EmailVerificationToken_userId_key`(`userId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `EmailVerificationToken` ADD CONSTRAINT `EmailVerificationToken_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `Users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -137,12 +137,14 @@ model Users {
   firstName  String
   email      String   @unique
   password   String
+  emailVerified Boolean @default(false)
   isResigned Boolean  @default(false)
   role       UserRole @default(USER)
   createdAt  DateTime @default(now())
   updatedAt  DateTime @updatedAt
 
   cart   Cart?
+  verificationToken VerificationToken?
   orders Orders[]
 }
 
@@ -156,4 +158,15 @@ enum OrderStatus {
   COMPLETED
   SHIPPED
   CANCELLED
+}
+
+
+model VerificationToken {
+  id        Int      @id @default(autoincrement())
+  token     String  @unique
+  userId    Int?    @unique
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  
+  user      Users?      @relation(fields: [userId], references: [id], onDelete: SetNull)
 }

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -144,7 +144,7 @@ model Users {
   updatedAt  DateTime @updatedAt
 
   cart   Cart?
-  verificationToken VerificationToken?
+  emailVerificationToken EmailVerificationToken?
   orders Orders[]
 }
 
@@ -161,12 +161,12 @@ enum OrderStatus {
 }
 
 
-model VerificationToken {
+model EmailVerificationToken {
   id        Int      @id @default(autoincrement())
   token     String  @unique
-  userId    Int?    @unique
+  userId    Int    @unique
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
   
-  user      Users?      @relation(fields: [userId], references: [id], onDelete: SetNull)
+  user      Users      @relation(fields: [userId], references: [id], onDelete: Cascade)
 }


### PR DESCRIPTION
新しくUserがアカウントを新規作成する際のEmail認証を通す用に、DBを変更しました。
Userに送るUUIDを含んだリンクを踏んでもらうことで認証することを想定しています。
イメージは以下の通りです。
<img width="992" height="342" alt="{361C1064-61FB-4BC8-B8FD-F3D56F6D4705}" src="https://github.com/user-attachments/assets/a048522c-31f0-405f-a016-356d6c9a9a33" />
