### PR TITLE
stripe webhook処理

### DIFF
--- a/api/src/contexts/checkout/controllers/StripeWebhookController.ts
+++ b/api/src/contexts/checkout/controllers/StripeWebhookController.ts
@@ -1,0 +1,53 @@
+import express from 'express';
+import { IHandleStripeWebhookInteractor } from '../usecases/IHandleStripeWebhookInteractor';
+import { IStripeAdapter } from '../domains/adapters/IStripeAdapter';
+
+export class StripeWebhookController {
+  constructor(
+    private readonly handleStripeWebhookInteractor: IHandleStripeWebhookInteractor,
+    private readonly stripeAdapter: IStripeAdapter,
+  ) {}
+
+  async execute(
+    req: express.Request,
+    res: express.Response,
+  ): Promise<express.Response> {
+    // Stripe署名ヘッダーの確認
+    const signature = req.headers['stripe-signature'];
+    if (!signature) {
+      return res
+        .status(400)
+        .json({ message: 'Missing stripe-signature header' });
+    }
+
+    if (typeof signature !== 'string') {
+      return res
+        .status(400)
+        .json({ message: 'Invalid stripe-signature header format' });
+    }
+
+    // Webhook Secretの確認
+    const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+    if (!webhookSecret) {
+      throw new Error('STRIPE_WEBHOOK_SECRET is not set');
+    }
+
+    try {
+      const event = await this.stripeAdapter.verifyWebhookSignature(
+        req.body,
+        signature,
+        webhookSecret,
+      );
+
+      await this.handleStripeWebhookInteractor.execute(event);
+
+      return res.status(200).json({ received: true });
+    } catch (error) {
+      console.error('Webhook signature verification failed:', error);
+      if (error instanceof Error) {
+        return res.status(400).json({ message: error.message });
+      }
+      return res.status(400).json({ message: 'Invalid signature' });
+    }
+  }
+}

--- a/api/src/contexts/checkout/controllers/StripeWebhookController.ts
+++ b/api/src/contexts/checkout/controllers/StripeWebhookController.ts
@@ -26,17 +26,10 @@ export class StripeWebhookController {
         .json({ message: 'Invalid stripe-signature header format' });
     }
 
-    // Webhook Secretの確認
-    const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
-    if (!webhookSecret) {
-      throw new Error('STRIPE_WEBHOOK_SECRET is not set');
-    }
-
     try {
       const event = await this.stripeAdapter.verifyWebhookSignature(
         req.body,
         signature,
-        webhookSecret,
       );
 
       await this.handleStripeWebhookInteractor.execute(event);

--- a/api/src/contexts/checkout/domains/adapters/IStripeAdapter.ts
+++ b/api/src/contexts/checkout/domains/adapters/IStripeAdapter.ts
@@ -1,3 +1,4 @@
+import Stripe from 'stripe';
 import {
   CheckoutSession,
   CheckoutSessionMode,
@@ -31,5 +32,5 @@ export interface IStripeAdapter {
     payload: string | Buffer,
     signature: string,
     secret: string,
-  ): Promise<any>;
+  ): Promise<Stripe.Event>;
 }

--- a/api/src/contexts/checkout/domains/adapters/IStripeAdapter.ts
+++ b/api/src/contexts/checkout/domains/adapters/IStripeAdapter.ts
@@ -31,6 +31,5 @@ export interface IStripeAdapter {
   verifyWebhookSignature(
     payload: string | Buffer,
     signature: string,
-    secret: string,
   ): Promise<Stripe.Event>;
 }

--- a/api/src/contexts/checkout/domains/adapters/IStripeAdapter.ts
+++ b/api/src/contexts/checkout/domains/adapters/IStripeAdapter.ts
@@ -25,4 +25,11 @@ export interface IStripeAdapter {
     requireShippingAddress?: boolean;
     metadata?: Record<string, string>;
   }): Promise<CheckoutSession>;
+
+  // Webhook署名を検証
+  verifyWebhookSignature(
+    payload: string | Buffer,
+    signature: string,
+    secret: string,
+  ): Promise<any>;
 }

--- a/api/src/contexts/checkout/index.ts
+++ b/api/src/contexts/checkout/index.ts
@@ -19,7 +19,17 @@ const itemRepository = new ItemRepository(prisma);
 const inventoryRepository = new InventoryRepository(prisma);
 const userRepository = new UserRepository(prisma);
 const orderRepository = new OrderRepository(prisma);
-const stripeAdapter = new StripeAdapter();
+
+const secretKey = process.env.STRIPE_SECRET_KEY;
+if (!secretKey) {
+  throw new Error('STRIPE_SECRET_KEY is not set');
+}
+
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+if (!webhookSecret) {
+  throw new Error('STRIPE_WEBHOOK_SECRET is not set');
+}
+const stripeAdapter = new StripeAdapter(secretKey, webhookSecret);
 
 const createCheckoutSessionInteractor = new CreateCheckoutSessionInteractor(
   cartRepository,

--- a/api/src/contexts/checkout/index.ts
+++ b/api/src/contexts/checkout/index.ts
@@ -1,8 +1,11 @@
 import { CreateCheckoutSessionController } from './controllers/CreateCheckoutSessionController';
 import { CreateCheckoutSessionInteractor } from './interactors/CreateCheckoutSessionInteractor';
+import { StripeWebhookController } from './controllers/StripeWebhookController';
+import { HandleStripeWebhookInteractor } from './interactors/HandleStripeWebhookInteractor';
 import { StripeAdapter } from './infrastructures/adapters/StripeAdapter';
 import { CartRepository } from '../cart/infrastructures/repositories/CartRepository';
 import { ItemRepository } from '../items/infrastructures/repositories/ItemRepository';
+import { InventoryRepository } from '../items/infrastructures/repositories/InventoryRepository';
 import { UserRepository } from '../users/infrastructures/repositories/UserRepository';
 import { OrderRepository } from '../orders/infrastructures/repositories/OrderRepository';
 import { prisma } from '../../libs/prisma';
@@ -13,6 +16,7 @@ const checkoutRouter = express.Router();
 
 const cartRepository = new CartRepository(prisma);
 const itemRepository = new ItemRepository(prisma);
+const inventoryRepository = new InventoryRepository(prisma);
 const userRepository = new UserRepository(prisma);
 const orderRepository = new OrderRepository(prisma);
 const stripeAdapter = new StripeAdapter();
@@ -29,10 +33,26 @@ const createCheckoutSessionController = new CreateCheckoutSessionController(
   createCheckoutSessionInteractor,
 );
 
+const handleStripeWebhookInteractor = new HandleStripeWebhookInteractor(
+  orderRepository,
+  inventoryRepository,
+);
+
+const stripeWebhookController = new StripeWebhookController(
+  handleStripeWebhookInteractor,
+  stripeAdapter,
+);
+
 checkoutRouter.post(
   '/session',
   verifyAccessToken,
   createCheckoutSessionController.execute.bind(createCheckoutSessionController),
+);
+
+checkoutRouter.post(
+  '/webhooks/stripe',
+  express.raw({ type: 'application/json' }),
+  stripeWebhookController.execute.bind(stripeWebhookController),
 );
 
 export { checkoutRouter };

--- a/api/src/contexts/checkout/index.ts
+++ b/api/src/contexts/checkout/index.ts
@@ -1,11 +1,8 @@
 import { CreateCheckoutSessionController } from './controllers/CreateCheckoutSessionController';
 import { CreateCheckoutSessionInteractor } from './interactors/CreateCheckoutSessionInteractor';
-import { StripeWebhookController } from './controllers/StripeWebhookController';
-import { HandleStripeWebhookInteractor } from './interactors/HandleStripeWebhookInteractor';
 import { StripeAdapter } from './infrastructures/adapters/StripeAdapter';
 import { CartRepository } from '../cart/infrastructures/repositories/CartRepository';
 import { ItemRepository } from '../items/infrastructures/repositories/ItemRepository';
-import { InventoryRepository } from '../items/infrastructures/repositories/InventoryRepository';
 import { UserRepository } from '../users/infrastructures/repositories/UserRepository';
 import { OrderRepository } from '../orders/infrastructures/repositories/OrderRepository';
 import { prisma } from '../../libs/prisma';
@@ -16,7 +13,6 @@ const checkoutRouter = express.Router();
 
 const cartRepository = new CartRepository(prisma);
 const itemRepository = new ItemRepository(prisma);
-const inventoryRepository = new InventoryRepository(prisma);
 const userRepository = new UserRepository(prisma);
 const orderRepository = new OrderRepository(prisma);
 const stripeAdapter = new StripeAdapter();
@@ -33,26 +29,10 @@ const createCheckoutSessionController = new CreateCheckoutSessionController(
   createCheckoutSessionInteractor,
 );
 
-const handleStripeWebhookInteractor = new HandleStripeWebhookInteractor(
-  orderRepository,
-  inventoryRepository,
-);
-
-const stripeWebhookController = new StripeWebhookController(
-  handleStripeWebhookInteractor,
-  stripeAdapter,
-);
-
 checkoutRouter.post(
   '/session',
   verifyAccessToken,
   createCheckoutSessionController.execute.bind(createCheckoutSessionController),
-);
-
-checkoutRouter.post(
-  '/webhooks/stripe',
-  express.raw({ type: 'application/json' }),
-  stripeWebhookController.execute.bind(stripeWebhookController),
 );
 
 export { checkoutRouter };

--- a/api/src/contexts/checkout/infrastructures/adapters/StripeAdapter.ts
+++ b/api/src/contexts/checkout/infrastructures/adapters/StripeAdapter.ts
@@ -7,15 +7,13 @@ import {
 
 export class StripeAdapter implements IStripeAdapter {
   private stripe: Stripe;
+  private webhookSecret: string;
 
-  constructor() {
-    const secretKey = process.env.STRIPE_SECRET_KEY;
-    if (!secretKey) {
-      throw new Error('STRIPE_SECRET_KEY is not set');
-    }
+  constructor(secretKey: string, webhookSecret: string) {
     this.stripe = new Stripe(secretKey, {
       apiVersion: '2025-11-17.clover',
     });
+    this.webhookSecret = webhookSecret;
   }
 
   async createCheckoutSession(params: {
@@ -83,8 +81,11 @@ export class StripeAdapter implements IStripeAdapter {
   async verifyWebhookSignature(
     payload: string | Buffer,
     signature: string,
-    secret: string,
   ): Promise<Stripe.Event> {
-    return this.stripe.webhooks.constructEvent(payload, signature, secret);
+    return this.stripe.webhooks.constructEvent(
+      payload,
+      signature,
+      this.webhookSecret,
+    );
   }
 }

--- a/api/src/contexts/checkout/infrastructures/adapters/StripeAdapter.ts
+++ b/api/src/contexts/checkout/infrastructures/adapters/StripeAdapter.ts
@@ -79,4 +79,12 @@ export class StripeAdapter implements IStripeAdapter {
       checkoutUrl: session.url ?? '',
     };
   }
+
+  async verifyWebhookSignature(
+    payload: string | Buffer,
+    signature: string,
+    secret: string,
+  ): Promise<any> {
+    return this.stripe.webhooks.constructEvent(payload, signature, secret);
+  }
 }

--- a/api/src/contexts/checkout/infrastructures/adapters/StripeAdapter.ts
+++ b/api/src/contexts/checkout/infrastructures/adapters/StripeAdapter.ts
@@ -84,7 +84,7 @@ export class StripeAdapter implements IStripeAdapter {
     payload: string | Buffer,
     signature: string,
     secret: string,
-  ): Promise<any> {
+  ): Promise<Stripe.Event> {
     return this.stripe.webhooks.constructEvent(payload, signature, secret);
   }
 }

--- a/api/src/contexts/checkout/interactors/CreateCheckoutSessionInteractor.ts
+++ b/api/src/contexts/checkout/interactors/CreateCheckoutSessionInteractor.ts
@@ -32,10 +32,11 @@ export class CreateCheckoutSessionInteractor
     }
 
     const successUrl =
-      process.env.CHECKOUT_SUCCESS_URL ??
+      process.env.CHECKOUT_SUCCESS_URL?.trim() ??
       'http://localhost:3000/order/complete';
     const cancelUrl =
-      process.env.CHECKOUT_CANCEL_URL ?? 'http://localhost:3000/products';
+      process.env.CHECKOUT_CANCEL_URL?.trim() ??
+      'http://localhost:3000/products';
 
     const lineItems = [];
     let hasPhysicalProduct = false;

--- a/api/src/contexts/checkout/interactors/HandleStripeWebhookInteractor.ts
+++ b/api/src/contexts/checkout/interactors/HandleStripeWebhookInteractor.ts
@@ -46,6 +46,21 @@ export class HandleStripeWebhookInteractor
       return;
     }
 
+    // PaymentIDの保存
+    if (session.payment_intent) {
+      const paymentId =
+        typeof session.payment_intent === 'string'
+          ? session.payment_intent
+          : session.payment_intent.id;
+      await this.orderRepository.updatePaymentExternalIdBySessionId(
+        session.id,
+        paymentId,
+      );
+      console.log(
+        `Payment ID ${paymentId} saved for session ${session.id}`,
+      );
+    }
+
     // 注文ステータスの更新
     await this.orderRepository.updateStatus(order.id, OrderStatus.COMPLETED);
     console.log(`Order ${order.id} status updated to COMPLETED`);

--- a/api/src/contexts/checkout/interactors/HandleStripeWebhookInteractor.ts
+++ b/api/src/contexts/checkout/interactors/HandleStripeWebhookInteractor.ts
@@ -61,6 +61,13 @@ export class HandleStripeWebhookInteractor
       );
     }
 
+    // 住所情報の更新（checkoutページで入力された住所）
+    if (session.shipping_details?.address) {
+      const address = this.formatShippingAddress(session.shipping_details.address);
+      await this.orderRepository.updateAddress(order.id, address);
+      console.log(`Order ${order.id} address updated: ${address}`);
+    }
+
     // 注文ステータスの更新
     await this.orderRepository.updateStatus(order.id, OrderStatus.COMPLETED);
     console.log(`Order ${order.id} status updated to COMPLETED`);
@@ -117,5 +124,39 @@ export class HandleStripeWebhookInteractor
         `Order ID not found in payment intent metadata: ${paymentIntent.id}`,
       );
     }
+  }
+
+  // Stripeの住所情報を文字列にフォーマット
+  private formatShippingAddress(
+    address: Stripe.Address,
+  ): string {
+    const parts: string[] = [];
+
+    // 郵便番号
+    if (address.postal_code) {
+      parts.push(`〒${address.postal_code}`);
+    }
+
+    // 都道府県
+    if (address.state) {
+      parts.push(address.state);
+    }
+
+    // 市区町村
+    if (address.city) {
+      parts.push(address.city);
+    }
+
+    // 番地（line1）
+    if (address.line1) {
+      parts.push(address.line1);
+    }
+
+    // 建物名・部屋番号（line2）
+    if (address.line2) {
+      parts.push(address.line2);
+    }
+
+    return parts.join(' ');
   }
 }

--- a/api/src/contexts/checkout/interactors/HandleStripeWebhookInteractor.ts
+++ b/api/src/contexts/checkout/interactors/HandleStripeWebhookInteractor.ts
@@ -1,0 +1,106 @@
+import { IHandleStripeWebhookInteractor } from '../usecases/IHandleStripeWebhookInteractor';
+import { IOrderRepository } from '../../orders/domains/repositories/IOrderRepository';
+import { IInventoryRepository } from '../../items/domains/repositories/IInventoryRepository';
+import { OrderStatus } from '@prisma/client';
+import Stripe from 'stripe';
+
+export class HandleStripeWebhookInteractor
+  implements IHandleStripeWebhookInteractor
+{
+  constructor(
+    private readonly orderRepository: IOrderRepository,
+    private readonly inventoryRepository: IInventoryRepository,
+  ) {}
+
+  async execute(event: Stripe.Event): Promise<void> {
+    switch (event.type) {
+      case 'checkout.session.completed':
+        await this.handleCheckoutSessionCompleted(event);
+        break;
+      case 'payment_intent.payment_failed':
+        await this.handlePaymentIntentPaymentFailed(event);
+        break;
+      default:
+        console.log(`Unhandled event type: ${event.type}`);
+    }
+  }
+
+  // ここから、決済完了後の処理をします
+  private async handleCheckoutSessionCompleted(
+    event: Stripe.Event,
+  ): Promise<void> {
+    const session = event.data.object as Stripe.Checkout.Session;
+
+    // StripeセッションIDから注文を取得
+    const order = await this.orderRepository.getByStripeSessionId(session.id);
+    if (!order) {
+      const errorMessage = `Order not found for session ID: ${session.id}`;
+      console.error(errorMessage);
+      throw new Error(errorMessage);
+    }
+
+    if (order.orderStatus === OrderStatus.COMPLETED) {
+      console.log(
+        `Order ${order.id} is already completed. Skipping duplicate webhook.`,
+      );
+      return;
+    }
+
+    // 注文ステータスの更新
+    await this.orderRepository.updateStatus(order.id, OrderStatus.COMPLETED);
+    console.log(`Order ${order.id} status updated to COMPLETED`);
+
+    // 在庫減算
+    for (const orderItem of order.items) {
+      // itemIdがnullの場合はスキップ（購入後、削除されている可能性があるため）
+      if (!orderItem.itemId) {
+        console.warn(
+          `OrderItem ${orderItem.id} has no itemId. Skipping inventory update.`,
+        );
+        continue;
+      }
+
+      try {
+        await this.inventoryRepository.decreaseStock(
+          orderItem.itemId,
+          orderItem.amount,
+        );
+        console.log(
+          `Inventory decreased: itemId=${orderItem.itemId}, amount=${orderItem.amount}`,
+        );
+      } catch (error) {
+        // 在庫減算に失敗した場合でも、注文は既に完了しているため、
+        // エラーをログに記録して処理を続行する
+        console.error(
+          `Failed to decrease inventory for itemId=${orderItem.itemId}, amount=${orderItem.amount}:`,
+          error,
+        );
+      }
+    }
+
+    console.log(
+      `Successfully processed checkout.session.completed for order ${order.id}`,
+    );
+  }
+
+  // 決済失敗時
+  private async handlePaymentIntentPaymentFailed(
+    event: Stripe.Event,
+  ): Promise<void> {
+    const paymentIntent = event.data.object as Stripe.PaymentIntent;
+
+    if (paymentIntent.metadata?.orderId) {
+      const orderId = parseInt(paymentIntent.metadata.orderId, 10);
+
+      await this.orderRepository.updateStatus(orderId, OrderStatus.CANCELLED);
+      console.log(
+        `Order ${orderId} status updated to CANCELLED (payment failed)`,
+      );
+    } else {
+      // metadataにorderIdが含まれていない場合は、エラーをログに記録
+      console.error(
+        `Order ID not found in payment intent metadata: ${paymentIntent.id}`,
+      );
+    }
+  }
+}

--- a/api/src/contexts/checkout/usecases/IHandleStripeWebhookInteractor.ts
+++ b/api/src/contexts/checkout/usecases/IHandleStripeWebhookInteractor.ts
@@ -1,0 +1,5 @@
+import Stripe from 'stripe';
+
+export interface IHandleStripeWebhookInteractor {
+  execute(event: Stripe.Event): Promise<void>;
+}

--- a/api/src/contexts/orders/interactors/UpdateOrderPaymentExternalIdInteractor.ts
+++ b/api/src/contexts/orders/interactors/UpdateOrderPaymentExternalIdInteractor.ts
@@ -19,4 +19,3 @@ export class UpdateOrderPaymentExternalIdInteractor
     );
   }
 }
-

--- a/api/src/contexts/orders/usecases/IUpdateOrderPaymentExternalIdInteractor.ts
+++ b/api/src/contexts/orders/usecases/IUpdateOrderPaymentExternalIdInteractor.ts
@@ -10,4 +10,3 @@ export interface IUpdateOrderPaymentExternalIdInteractor {
     params: UpdateOrderPaymentExternalIdParams,
   ): Promise<OrderPaymentExternalId | null>;
 }
-

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -15,6 +15,11 @@ import { cartRouter } from './contexts/cart';
 import { checkoutRouter } from './contexts/checkout';
 import { ordersRouter } from './contexts/orders';
 import { adminOrdersRouter } from './contexts/orders/admin';
+import { StripeWebhookController } from './contexts/checkout/controllers/StripeWebhookController';
+import { HandleStripeWebhookInteractor } from './contexts/checkout/interactors/HandleStripeWebhookInteractor';
+import { StripeAdapter } from './contexts/checkout/infrastructures/adapters/StripeAdapter';
+import { OrderRepository } from './contexts/orders/infrastructures/repositories/OrderRepository';
+import { InventoryRepository } from './contexts/items/infrastructures/repositories/InventoryRepository';
 
 const app = express();
 
@@ -26,6 +31,28 @@ app.use(
 );
 
 app.use(cookieParser());
+
+// Webhookエンドポイントは express.json() の適用前に配置する必要がある
+// Stripeの署名検証には生のリクエストボディが必要
+const orderRepository = new OrderRepository(prisma);
+const inventoryRepository = new InventoryRepository(prisma);
+const stripeAdapter = new StripeAdapter();
+const handleStripeWebhookInteractor = new HandleStripeWebhookInteractor(
+  orderRepository,
+  inventoryRepository,
+);
+const stripeWebhookController = new StripeWebhookController(
+  handleStripeWebhookInteractor,
+  stripeAdapter,
+);
+
+app.post(
+  '/checkout/webhooks/stripe',
+  express.raw({ type: 'application/json' }),
+  stripeWebhookController.execute.bind(stripeWebhookController),
+);
+
+// その他のエンドポイントには express.json() を適用
 app.use(express.json());
 
 app.get('/', async (_req: Request, res: Response) => {


### PR DESCRIPTION
## 内容
決済完了後、以下を処理する

- stripe セッションIDから注文を取得
- 注文ステータスの更新
- payment IDを保存（未実装）
- 物理商品であれば、住所情報を保存（未実装）
- 購入された商品の在庫を減算
- ユーザーのカートをクリア（未実装）