### PR TITLE
paymentID更新API

### DIFF
--- a/api/src/contexts/orders/domains/repositories/IOrderRepository.ts
+++ b/api/src/contexts/orders/domains/repositories/IOrderRepository.ts
@@ -37,4 +37,8 @@ export interface IOrderRepository {
   createPaymentExternalId(
     data: CreateOrderPaymentExternalIdData,
   ): Promise<OrderPaymentExternalId>;
+  updatePaymentExternalIdBySessionId(
+    paymentSessionId: string,
+    paymentId: string,
+  ): Promise<OrderPaymentExternalId | null>;
 }

--- a/api/src/contexts/orders/infrastructures/repositories/OrderRepository.ts
+++ b/api/src/contexts/orders/infrastructures/repositories/OrderRepository.ts
@@ -124,6 +124,44 @@ export class OrderRepository implements IOrderRepository {
     };
   }
 
+  async updatePaymentExternalIdBySessionId(
+    paymentSessionId: string,
+    paymentId: string,
+  ): Promise<OrderPaymentExternalId | null> {
+    const paymentExternalId =
+      await this.prisma.orderPaymentExternalIds.findUnique({
+        where: {
+          provider_paymentSessionId: {
+            provider: 'STRIPE',
+            paymentSessionId,
+          },
+        },
+      });
+
+    if (!paymentExternalId) {
+      return null;
+    }
+
+    const updated = await this.prisma.orderPaymentExternalIds.update({
+      where: {
+        id: paymentExternalId.id,
+      },
+      data: {
+        paymentId,
+      },
+    });
+
+    return {
+      id: updated.id,
+      orderId: updated.orderId,
+      provider: updated.provider,
+      paymentSessionId: updated.paymentSessionId,
+      paymentId: updated.paymentId,
+      createdAt: updated.createdAt,
+      updatedAt: updated.updatedAt,
+    };
+  }
+
   private mapToOrder(
     order: Prisma.OrdersGetPayload<{
       include: { orderItems: true };

--- a/api/src/contexts/orders/interactors/UpdateOrderPaymentExternalIdInteractor.ts
+++ b/api/src/contexts/orders/interactors/UpdateOrderPaymentExternalIdInteractor.ts
@@ -1,0 +1,22 @@
+import {
+  IUpdateOrderPaymentExternalIdInteractor,
+  UpdateOrderPaymentExternalIdParams,
+} from '../usecases/IUpdateOrderPaymentExternalIdInteractor';
+import { IOrderRepository } from '../domains/repositories/IOrderRepository';
+import { OrderPaymentExternalId } from '../domains/entities/OrderPaymentExternalId';
+
+export class UpdateOrderPaymentExternalIdInteractor
+  implements IUpdateOrderPaymentExternalIdInteractor
+{
+  constructor(private readonly orderRepository: IOrderRepository) {}
+
+  async execute(
+    params: UpdateOrderPaymentExternalIdParams,
+  ): Promise<OrderPaymentExternalId | null> {
+    return await this.orderRepository.updatePaymentExternalIdBySessionId(
+      params.paymentSessionId,
+      params.paymentId,
+    );
+  }
+}
+

--- a/api/src/contexts/orders/usecases/IUpdateOrderPaymentExternalIdInteractor.ts
+++ b/api/src/contexts/orders/usecases/IUpdateOrderPaymentExternalIdInteractor.ts
@@ -1,0 +1,13 @@
+import { OrderPaymentExternalId } from '../domains/entities/OrderPaymentExternalId';
+
+export interface UpdateOrderPaymentExternalIdParams {
+  paymentSessionId: string;
+  paymentId: string;
+}
+
+export interface IUpdateOrderPaymentExternalIdInteractor {
+  execute(
+    params: UpdateOrderPaymentExternalIdParams,
+  ): Promise<OrderPaymentExternalId | null>;
+}
+


### PR DESCRIPTION
## 内容

stripe決済後に対象のsessionIDのpaymentIDを保存しにいく。

paymentIDは注文のキャンセルや、決済情報野取得に使用される。