### PR TITLE
ユーザー登録・退会のAPIテスト作成

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -8,7 +8,12 @@ module.exports = {
   testEnvironment: "node",
   transform: {
     ...tsJestTransformCfg,
+    "^.+\\.mjs$": ["ts-jest", { useESM: false }],
+    "^.+\\.js$": ["ts-jest", { useESM: false }],
   },
+  transformIgnorePatterns: [
+    "node_modules/(?!(jose)/)",
+  ],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   testTimeout: 30000,
   testMatch: ["<rootDir>/src/**/*.test.ts"],

--- a/api/src/contexts/users/controllers/CreateUserController.test.ts
+++ b/api/src/contexts/users/controllers/CreateUserController.test.ts
@@ -23,12 +23,13 @@ describe('CreateUserController', () => {
 
   describe('POST /users/signup', () => {
     it('should create a user successfully', async () => {
+      const email = 'test-success@example.com';
       const response = await request(app)
         .post('/users/signup')
         .send({
           lastName: '山田',
           firstName: '太郎',
-          email: 'test@example.com',
+          email,
           password: 'password123',
         })
         .expect(201);
@@ -37,17 +38,14 @@ describe('CreateUserController', () => {
       expect(response.body.createdUser).toHaveProperty('id');
       expect(response.body.createdUser).toHaveProperty('lastName', '山田');
       expect(response.body.createdUser).toHaveProperty('firstName', '太郎');
-      expect(response.body.createdUser).toHaveProperty(
-        'email',
-        'test@example.com',
-      );
+      expect(response.body.createdUser).toHaveProperty('email', email);
       expect(response.body.createdUser).toHaveProperty('password');
       expect(response.body.createdUser).toHaveProperty('role', 'USER');
       expect(response.body.createdUser).toHaveProperty('isResigned', false);
 
       // データベースに保存されていることを確認
       const createdUser = await prismaTest.users.findUnique({
-        where: { email: 'test@example.com' },
+        where: { email },
       });
       expect(createdUser).not.toBeNull();
       expect(createdUser?.lastName).toBe('山田');
@@ -59,7 +57,7 @@ describe('CreateUserController', () => {
         .post('/users/signup')
         .send({
           firstName: '太郎',
-          email: 'test@example.com',
+          email: 'test-lastname@example.com',
           password: 'password123',
         })
         .expect(400);
@@ -75,7 +73,7 @@ describe('CreateUserController', () => {
         .post('/users/signup')
         .send({
           lastName: '山田',
-          email: 'test@example.com',
+          email: 'test-firstname@example.com',
           password: 'password123',
         })
         .expect(400);
@@ -108,7 +106,7 @@ describe('CreateUserController', () => {
         .send({
           lastName: '山田',
           firstName: '太郎',
-          email: 'test@example.com',
+          email: 'test-password@example.com',
         })
         .expect(400);
 
@@ -147,18 +145,19 @@ describe('CreateUserController', () => {
     });
 
     it('should hash password before saving', async () => {
+      const email = 'test-hash@example.com';
       await request(app)
         .post('/users/signup')
         .send({
           lastName: '山田',
           firstName: '太郎',
-          email: 'test@example.com',
+          email,
           password: 'password123',
         })
         .expect(201);
 
       const createdUser = await prismaTest.users.findUnique({
-        where: { email: 'test@example.com' },
+        where: { email },
       });
 
       expect(createdUser).not.toBeNull();

--- a/api/src/contexts/users/controllers/CreateUserController.test.ts
+++ b/api/src/contexts/users/controllers/CreateUserController.test.ts
@@ -1,0 +1,169 @@
+import request from 'supertest';
+import { createTestApp } from '../../../tests/helpers/app';
+import { createRouter } from '../../../tests/helpers/router';
+import { CreateUserController } from './CreateUserController';
+import { CreateUserInteractor } from '../interactors/CreateUserInteractor';
+import { UserRepository } from '../infrastructures/repositories/UserRepository';
+import { prismaTest } from '../../../libs/prisma-test';
+import { cleanDatabase } from '../../../tests/helpers/database';
+
+describe('CreateUserController', () => {
+  let app: ReturnType<typeof createTestApp>;
+
+  beforeEach(async () => {
+    await cleanDatabase();
+
+    const userRepository = new UserRepository(prismaTest);
+    const createUserInteractor = new CreateUserInteractor(userRepository);
+    const createUserController = new CreateUserController(createUserInteractor);
+    const router = createRouter('POST', '/signup', createUserController);
+
+    app = createTestApp([{ path: '/users', router }]);
+  });
+
+  describe('POST /users/signup', () => {
+    it('should create a user successfully', async () => {
+      const response = await request(app)
+        .post('/users/signup')
+        .send({
+          lastName: '山田',
+          firstName: '太郎',
+          email: 'test@example.com',
+          password: 'password123',
+        })
+        .expect(201);
+
+      expect(response.body).toHaveProperty('createdUser');
+      expect(response.body.createdUser).toHaveProperty('id');
+      expect(response.body.createdUser).toHaveProperty('lastName', '山田');
+      expect(response.body.createdUser).toHaveProperty('firstName', '太郎');
+      expect(response.body.createdUser).toHaveProperty(
+        'email',
+        'test@example.com',
+      );
+      expect(response.body.createdUser).toHaveProperty('password');
+      expect(response.body.createdUser).toHaveProperty('role', 'USER');
+      expect(response.body.createdUser).toHaveProperty('isResigned', false);
+
+      // データベースに保存されていることを確認
+      const createdUser = await prismaTest.users.findUnique({
+        where: { email: 'test@example.com' },
+      });
+      expect(createdUser).not.toBeNull();
+      expect(createdUser?.lastName).toBe('山田');
+      expect(createdUser?.firstName).toBe('太郎');
+    });
+
+    it('should return 400 when lastName is missing', async () => {
+      const response = await request(app)
+        .post('/users/signup')
+        .send({
+          firstName: '太郎',
+          email: 'test@example.com',
+          password: 'password123',
+        })
+        .expect(400);
+
+      expect(response.body).toHaveProperty(
+        'message',
+        'Missing required fields',
+      );
+    });
+
+    it('should return 400 when firstName is missing', async () => {
+      const response = await request(app)
+        .post('/users/signup')
+        .send({
+          lastName: '山田',
+          email: 'test@example.com',
+          password: 'password123',
+        })
+        .expect(400);
+
+      expect(response.body).toHaveProperty(
+        'message',
+        'Missing required fields',
+      );
+    });
+
+    it('should return 400 when email is missing', async () => {
+      const response = await request(app)
+        .post('/users/signup')
+        .send({
+          lastName: '山田',
+          firstName: '太郎',
+          password: 'password123',
+        })
+        .expect(400);
+
+      expect(response.body).toHaveProperty(
+        'message',
+        'Missing required fields',
+      );
+    });
+
+    it('should return 400 when password is missing', async () => {
+      const response = await request(app)
+        .post('/users/signup')
+        .send({
+          lastName: '山田',
+          firstName: '太郎',
+          email: 'test@example.com',
+        })
+        .expect(400);
+
+      expect(response.body).toHaveProperty(
+        'message',
+        'Missing required fields',
+      );
+    });
+
+    it('should return 400 when email already exists', async () => {
+      // 既存のユーザーを作成
+      await prismaTest.users.create({
+        data: {
+          lastName: '既存',
+          firstName: 'ユーザー',
+          email: 'existing@example.com',
+          password: 'hashedpassword',
+          role: 'USER',
+          isResigned: false,
+        },
+      });
+
+      const response = await request(app)
+        .post('/users/signup')
+        .send({
+          lastName: '新規',
+          firstName: 'ユーザー',
+          email: 'existing@example.com',
+          password: 'password123',
+        })
+        .expect(500);
+
+      // コントローラーのエラーハンドリングが正しく動作していないため、
+      // interactorのエラーメッセージ "Email already exists" が500エラーとして返される
+      expect(response.body).toHaveProperty('message', 'Internal server error');
+    });
+
+    it('should hash password before saving', async () => {
+      await request(app)
+        .post('/users/signup')
+        .send({
+          lastName: '山田',
+          firstName: '太郎',
+          email: 'test@example.com',
+          password: 'password123',
+        })
+        .expect(201);
+
+      const createdUser = await prismaTest.users.findUnique({
+        where: { email: 'test@example.com' },
+      });
+
+      expect(createdUser).not.toBeNull();
+      expect(createdUser?.password).not.toBe('password123');
+      expect(createdUser?.password).toHaveLength(60); // bcrypt hash length
+    });
+  });
+});

--- a/api/src/contexts/users/controllers/DeleteUserController.test.ts
+++ b/api/src/contexts/users/controllers/DeleteUserController.test.ts
@@ -1,0 +1,70 @@
+import request from 'supertest';
+import { createTestApp } from '../../../tests/helpers/app';
+import { createRouter } from '../../../tests/helpers/router';
+import { DeleteUserController } from './DeleteUserController';
+import { DeleteUserInteractor } from '../interactors/DeleteUserInteractor';
+import { UserRepository } from '../infrastructures/repositories/UserRepository';
+import { VerifyUserInteractor } from '../../auth/interactors/VerifyUserInteractor';
+import { createVerifyAccessToken } from '../../../middlewares/verifyAccessToken';
+import { prismaTest } from '../../../libs/prisma-test';
+import { cleanDatabase } from '../../../tests/helpers/database';
+import { generateJWT } from '../../../utils/jwt';
+
+describe('DeleteUserController', () => {
+  let app: ReturnType<typeof createTestApp>;
+  let verifyAccessToken: ReturnType<typeof createVerifyAccessToken>;
+
+  beforeEach(async () => {
+    await cleanDatabase();
+
+    const userRepository = new UserRepository(prismaTest);
+    const verifyUserInteractor = new VerifyUserInteractor(userRepository);
+    verifyAccessToken = createVerifyAccessToken(verifyUserInteractor);
+
+    const deleteUserInteractor = new DeleteUserInteractor(userRepository);
+    const deleteUserController = new DeleteUserController(deleteUserInteractor);
+    const router = createRouter('DELETE', '/:id', deleteUserController, [
+      verifyAccessToken,
+    ]);
+
+    app = createTestApp([{ path: '/users', router }]);
+  });
+
+  describe('DELETE /users/:id', () => {
+    it('should delete a user successfully', async () => {
+      // テスト用ユーザーを作成
+      const testUser = await prismaTest.users.create({
+        data: {
+          lastName: '削除',
+          firstName: 'テスト',
+          email: 'delete@example.com',
+          password: 'hashedpassword',
+          role: 'USER',
+          isResigned: false,
+        },
+      });
+
+      // 認証用のトークンを生成
+      const token = await generateJWT({
+        userId: testUser.id,
+        email: testUser.email,
+        role: testUser.role,
+        version: '1.0',
+      });
+
+      const response = await request(app)
+        .delete(`/users/${testUser.id}`)
+        .set('Cookie', `token=${token}`)
+        .expect(200);
+
+      expect(response.body).toEqual({ success: true });
+
+      // ユーザーが削除（isResigned=true）されていることを確認
+      const deletedUser = await prismaTest.users.findUnique({
+        where: { id: testUser.id },
+      });
+      expect(deletedUser).not.toBeNull();
+      expect(deletedUser?.isResigned).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
後続PRでユーザー登録と退会のリファクタリングをしようと思っており、先にAPIテストを作成しました。
（後続PRの修正後に同じAPIテストが通っていれば、元の振る舞いが担保されていることを簡単に確認できるため）