### PR TITLE
注文管理画面の追加

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -20,6 +20,8 @@ import { AdminProductList } from './pages/admin/AdminProductList';
 import { AdminProductCreate } from './pages/admin/AdminProductCreate';
 import { AdminProductEdit } from './pages/admin/AdminProductEdit';
 import { AdminProductDelete } from './pages/admin/AdminProductDelete';
+import { AdminAllOrdersList } from './pages/admin/AdminAllOrdersList';
+import { AdminOrderList } from './pages/admin/AdminOrderList';
 import { Cart } from './pages/user/Cart';
 import { MyPage } from './pages/user/MyPage';
 import { OrderHistory } from './pages/user/OrderHistory';
@@ -76,6 +78,11 @@ function App(): React.JSX.Element {
                 <Route
                   path="/admin/products/:id/delete"
                   element={<AdminProductDelete />}
+                />
+                <Route path="/admin/orders" element={<AdminAllOrdersList />} />
+                <Route
+                  path="/admin/orders/shipping"
+                  element={<AdminOrderList />}
                 />
               </Routes>
               <Routes>

--- a/front/src/pages/admin/AdminAllOrdersList.tsx
+++ b/front/src/pages/admin/AdminAllOrdersList.tsx
@@ -1,0 +1,143 @@
+import React, { useState, useEffect } from 'react';
+import { getAllOrders } from '../../services/api/orders';
+import { GetRes } from '@shared/types/gets';
+
+type Order = GetRes['/admin/orders']['orders'][0];
+
+export const AdminAllOrdersList: React.FC = () => {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchOrders = async (): Promise<void> => {
+      try {
+        setLoading(true);
+        const response = await getAllOrders();
+        setOrders(response.orders);
+        setError(null);
+      } catch (err) {
+        setError('注文の取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchOrders();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto py-8">
+        <div className="text-center text-gray-500">読み込み中...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto py-8">
+        <div className="text-center text-red-500">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-bold">すべての購入管理</h1>
+      </div>
+
+      {orders.length === 0 ? (
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <p className="text-gray-500 text-center">注文がありません</p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {orders.map((order) => (
+            <div
+              key={order.id}
+              className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow"
+            >
+              <div className="flex justify-between items-start mb-4">
+                <div>
+                  <h2 className="text-xl font-bold mb-2">注文ID: {order.id}</h2>
+                  <div className="text-sm text-gray-600 space-y-1">
+                    <p>
+                      <span className="font-medium">お名前:</span>{' '}
+                      {order.lastName} {order.firstName}
+                    </p>
+                    <p>
+                      <span className="font-medium">メールアドレス:</span>{' '}
+                      {order.email}
+                    </p>
+                    <p>
+                      <span className="font-medium">配送先:</span>{' '}
+                      {order.address}
+                    </p>
+                    <p>
+                      <span className="font-medium">注文日時:</span>{' '}
+                      {new Date(order.createdAt).toLocaleString('ja-JP')}
+                    </p>
+                    <p>
+                      <span className="font-medium">合計金額:</span> ¥
+                      {order.totalPrice.toLocaleString()}
+                    </p>
+                    {order.trackingNumber && (
+                      <p>
+                        <span className="font-medium">追跡番号:</span>{' '}
+                        {order.trackingNumber}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <div className="ml-4">
+                  <span
+                    className={`px-3 py-1 rounded-full text-sm font-medium ${
+                      order.orderStatus === 'COMPLETED'
+                        ? 'bg-green-100 text-green-800'
+                        : order.orderStatus === 'SHIPPED'
+                          ? 'bg-blue-100 text-blue-800'
+                          : order.orderStatus === 'CANCELLED'
+                            ? 'bg-gray-100 text-gray-800'
+                            : 'bg-yellow-100 text-yellow-800'
+                    }`}
+                  >
+                    {order.orderStatus === 'COMPLETED'
+                      ? '完了'
+                      : order.orderStatus === 'SHIPPED'
+                        ? '発送済み'
+                        : order.orderStatus === 'CANCELLED'
+                          ? 'キャンセル'
+                          : order.orderStatus === 'PENDING'
+                            ? '処理中'
+                            : order.orderStatus}
+                  </span>
+                </div>
+              </div>
+
+              <div className="border-t pt-4 mt-4">
+                <h3 className="font-medium mb-2">注文商品:</h3>
+                <ul className="space-y-2">
+                  {order.items.map((item: Order['items'][0]) => (
+                    <li
+                      key={item.id}
+                      className="flex justify-between items-center text-sm"
+                    >
+                      <span>
+                        {item.itemName} × {item.amount}
+                      </span>
+                      <span className="text-gray-600">
+                        ¥{(item.itemPrice * item.amount).toLocaleString()}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/front/src/pages/admin/AdminOrderList.tsx
+++ b/front/src/pages/admin/AdminOrderList.tsx
@@ -1,0 +1,142 @@
+import React, { useState, useEffect } from 'react';
+import { getOrdersNeedingShipping } from '../../services/api/orders';
+import { GetRes } from '@shared/types/gets';
+
+type Order = GetRes['/admin/orders/shipping-needed']['orders'][0];
+
+export const AdminOrderList: React.FC = () => {
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchOrders = async (): Promise<void> => {
+      try {
+        setLoading(true);
+        const response = await getOrdersNeedingShipping();
+        setOrders(response.orders);
+        setError(null);
+      } catch (err) {
+        setError('注文の取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchOrders();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="container mx-auto py-8">
+        <div className="text-center text-gray-500">読み込み中...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto py-8">
+        <div className="text-center text-red-500">{error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto py-8">
+      <div className="flex justify-between items-center mb-6">
+        <h1 className="text-3xl font-bold">配送管理</h1>
+        <p className="text-sm text-gray-600">
+          配送が必要な注文のみ表示されます
+        </p>
+      </div>
+
+      {orders.length === 0 ? (
+        <div className="bg-white rounded-lg shadow-md p-6">
+          <p className="text-gray-500 text-center">
+            配送が必要な注文はありません
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {orders.map((order) => (
+            <div
+              key={order.id}
+              className="bg-white rounded-lg shadow-md p-6 hover:shadow-lg transition-shadow"
+            >
+              <div className="flex justify-between items-start mb-4">
+                <div>
+                  <h2 className="text-xl font-bold mb-2">注文ID: {order.id}</h2>
+                  <div className="text-sm text-gray-600 space-y-1">
+                    <p>
+                      <span className="font-medium">お名前:</span>{' '}
+                      {order.lastName} {order.firstName}
+                    </p>
+                    <p>
+                      <span className="font-medium">メールアドレス:</span>{' '}
+                      {order.email}
+                    </p>
+                    <p>
+                      <span className="font-medium">配送先:</span>{' '}
+                      {order.address}
+                    </p>
+                    <p>
+                      <span className="font-medium">注文日時:</span>{' '}
+                      {new Date(order.createdAt).toLocaleString('ja-JP')}
+                    </p>
+                    <p>
+                      <span className="font-medium">合計金額:</span> ¥
+                      {order.totalPrice.toLocaleString()}
+                    </p>
+                    {order.trackingNumber && (
+                      <p>
+                        <span className="font-medium">追跡番号:</span>{' '}
+                        {order.trackingNumber}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <div className="ml-4">
+                  <span
+                    className={`px-3 py-1 rounded-full text-sm font-medium ${
+                      order.orderStatus === 'COMPLETED'
+                        ? 'bg-green-100 text-green-800'
+                        : order.orderStatus === 'SHIPPED'
+                          ? 'bg-blue-100 text-blue-800'
+                          : 'bg-gray-100 text-gray-800'
+                    }`}
+                  >
+                    {order.orderStatus === 'COMPLETED'
+                      ? '配送待ち'
+                      : order.orderStatus === 'SHIPPED'
+                        ? '発送済み'
+                        : order.orderStatus}
+                  </span>
+                </div>
+              </div>
+
+              <div className="border-t pt-4 mt-4">
+                <h3 className="font-medium mb-2">注文商品:</h3>
+                <ul className="space-y-2">
+                  {order.items.map((item: Order['items'][0]) => (
+                    <li
+                      key={item.id}
+                      className="flex justify-between items-center text-sm"
+                    >
+                      <span>
+                        {item.itemName} × {item.amount}
+                      </span>
+                      <span className="text-gray-600">
+                        ¥{(item.itemPrice * item.amount).toLocaleString()}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/front/src/pages/admin/AdminOrderList.tsx
+++ b/front/src/pages/admin/AdminOrderList.tsx
@@ -8,6 +8,9 @@ export const AdminOrderList: React.FC = () => {
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [editingOrderId, setEditingOrderId] = useState<number | null>(null);
+  const [trackingNumber, setTrackingNumber] = useState('');
+  const [updating, setUpdating] = useState(false);
 
   useEffect(() => {
     const fetchOrders = async (): Promise<void> => {
@@ -25,6 +28,16 @@ export const AdminOrderList: React.FC = () => {
 
     fetchOrders();
   }, []);
+
+  const handleShipOrder = async (orderId: number): Promise<void> => {
+    if (!trackingNumber.trim()) {
+      alert('追跡番号を入力してください');
+      return;
+    }
+
+    // TODO: バックエンドAPI実装後に有効化
+    alert('追跡番号を登録する機能は、バックエンドAPI実装後に有効化');
+  };
 
   if (loading) {
     return (
@@ -96,7 +109,7 @@ export const AdminOrderList: React.FC = () => {
                     )}
                   </div>
                 </div>
-                <div className="ml-4">
+                <div className="ml-4 flex flex-col items-end gap-2">
                   <span
                     className={`px-3 py-1 rounded-full text-sm font-medium ${
                       order.orderStatus === 'COMPLETED'
@@ -112,6 +125,46 @@ export const AdminOrderList: React.FC = () => {
                         ? '発送済み'
                         : order.orderStatus}
                   </span>
+                  {order.orderStatus === 'COMPLETED' && (
+                    <div>
+                      {editingOrderId === order.id ? (
+                        <div className="flex gap-2">
+                          <input
+                            type="text"
+                            value={trackingNumber}
+                            onChange={(e) => setTrackingNumber(e.target.value)}
+                            placeholder="追跡番号"
+                            className="border rounded px-3 py-2 text-sm w-48"
+                            disabled={updating}
+                          />
+                          <button
+                            onClick={() => handleShipOrder(order.id)}
+                            disabled={updating}
+                            className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600 text-sm disabled:bg-gray-400 disabled:cursor-not-allowed"
+                          >
+                            {updating ? '処理中...' : '発送'}
+                          </button>
+                          <button
+                            onClick={() => {
+                              setEditingOrderId(null);
+                              setTrackingNumber('');
+                            }}
+                            disabled={updating}
+                            className="bg-gray-500 text-white px-4 py-2 rounded hover:bg-gray-600 text-sm disabled:bg-gray-400 disabled:cursor-not-allowed"
+                          >
+                            キャンセル
+                          </button>
+                        </div>
+                      ) : (
+                        <button
+                          onClick={() => setEditingOrderId(order.id)}
+                          className="bg-green-500 text-white px-4 py-2 rounded hover:bg-green-600 text-sm"
+                        >
+                          発送処理
+                        </button>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
 

--- a/front/src/pages/user/MyPage.tsx
+++ b/front/src/pages/user/MyPage.tsx
@@ -85,6 +85,16 @@ export const MyPage: React.FC = () => {
               </div>
               <ChevronRightIcon className="w-5 h-5 text-gray-400 group-hover:text-gray-600 transition-colors" />
             </Link>
+            <Link
+              to="/admin/orders/shipping"
+              className="flex items-center justify-between p-4 rounded-lg hover:bg-gray-50 transition-colors group"
+            >
+              <div className="flex items-center space-x-4">
+                <ClipboardDocumentListIcon className="w-6 h-6 text-gray-600 group-hover:text-gray-900 transition-colors" />
+                <span className="text-gray-900 font-medium">配送管理</span>
+              </div>
+              <ChevronRightIcon className="w-5 h-5 text-gray-400 group-hover:text-gray-600 transition-colors" />
+            </Link>
           </div>
         </div>
       )}

--- a/front/src/services/api/orders.ts
+++ b/front/src/services/api/orders.ts
@@ -5,3 +5,18 @@ export async function getOrders(): Promise<GetRes['/orders']> {
   const response = await apiClient.get<GetRes['/orders']>('/orders');
   return response.data;
 }
+
+export async function getAllOrders(): Promise<GetRes['/admin/orders']> {
+  const response =
+    await apiClient.get<GetRes['/admin/orders']>('/admin/orders');
+  return response.data;
+}
+
+export async function getOrdersNeedingShipping(): Promise<
+  GetRes['/admin/orders/shipping-needed']
+> {
+  const response = await apiClient.get<GetRes['/admin/orders/shipping-needed']>(
+    '/admin/orders/shipping-needed',
+  );
+  return response.data;
+}


### PR DESCRIPTION
## 画面

すべての注文を確認する画面と配送処理が必要なものだけの画面を作成しました。

https://github.com/user-attachments/assets/c40f878c-0b18-4f3e-b02c-b6c463979015

## 備考

- 配送フローとして、追跡番号は配送業者が発行するはずなので、適当な文字列をいれられるようにしています。