### PR TITLE
追跡番号保存のAPI

### DIFF
--- a/api/src/contexts/orders/admin/controllers/UpdateOrderTrackingController.ts
+++ b/api/src/contexts/orders/admin/controllers/UpdateOrderTrackingController.ts
@@ -1,0 +1,51 @@
+import express from 'express';
+import { IUpdateOrderTrackingInteractor } from '../usecases/IUpdateOrderTrackingInteractor';
+
+export class UpdateOrderTrackingController {
+  constructor(
+    private readonly updateOrderTrackingInteractor: IUpdateOrderTrackingInteractor,
+  ) {}
+
+  async execute(
+    req: express.Request<{ id: string }>,
+    res: express.Response,
+  ): Promise<void> {
+    try {
+      const orderId = parseInt(req.params.id, 10);
+      const { trackingNumber } = req.body;
+
+      if (isNaN(orderId)) {
+        res.status(400).json({ error: 'Invalid order ID' });
+        return;
+      }
+
+      if (!trackingNumber || typeof trackingNumber !== 'string') {
+        res.status(400).json({ error: 'Tracking number is required' });
+        return;
+      }
+
+      await this.updateOrderTrackingInteractor.execute(
+        orderId,
+        trackingNumber.trim(),
+      );
+
+      res.status(200).json({ message: 'Tracking number updated successfully' });
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.message === 'Order not found') {
+          res.status(404).json({ error: error.message });
+          return;
+        }
+        if (
+          error.message === 'This order does not contain physical items' ||
+          error.message === 'This order has already been shipped' ||
+          error.message === 'This order is not ready for shipping'
+        ) {
+          res.status(400).json({ error: error.message });
+          return;
+        }
+      }
+      throw error;
+    }
+  }
+}

--- a/api/src/contexts/orders/admin/index.ts
+++ b/api/src/contexts/orders/admin/index.ts
@@ -2,6 +2,8 @@ import { GetOrdersController } from './controllers/GetOrdersController';
 import { GetOrdersInteractor } from './interactors/GetOrdersInteractor';
 import { GetOrdersNeedingShippingController } from './controllers/GetOrdersNeedingShippingController';
 import { GetOrdersNeedingShippingInteractor } from './interactors/GetOrdersNeedingShippingInteractor';
+import { UpdateOrderTrackingController } from './controllers/UpdateOrderTrackingController';
+import { UpdateOrderTrackingInteractor } from './interactors/UpdateOrderTrackingInteractor';
 import { OrderRepository } from '../infrastructures/repositories/OrderRepository';
 import { prisma } from '../../../libs/prisma';
 import express from 'express';
@@ -16,6 +18,12 @@ const getOrdersNeedingShippingInteractor =
   new GetOrdersNeedingShippingInteractor(orderRepository);
 const getOrdersNeedingShippingController =
   new GetOrdersNeedingShippingController(getOrdersNeedingShippingInteractor);
+const updateOrderTrackingInteractor = new UpdateOrderTrackingInteractor(
+  orderRepository,
+);
+const updateOrderTrackingController = new UpdateOrderTrackingController(
+  updateOrderTrackingInteractor,
+);
 
 adminOrdersRouter.use(verifyAccessToken);
 adminOrdersRouter.use(verifyAdmin);
@@ -30,6 +38,11 @@ adminOrdersRouter.get(
   getOrdersNeedingShippingController.execute.bind(
     getOrdersNeedingShippingController,
   ),
+);
+
+adminOrdersRouter.patch(
+  '/:id/tracking',
+  updateOrderTrackingController.execute.bind(updateOrderTrackingController),
 );
 
 export { adminOrdersRouter };

--- a/api/src/contexts/orders/admin/interactors/UpdateOrderTrackingInteractor.ts
+++ b/api/src/contexts/orders/admin/interactors/UpdateOrderTrackingInteractor.ts
@@ -1,0 +1,50 @@
+import { IUpdateOrderTrackingInteractor } from '../usecases/IUpdateOrderTrackingInteractor';
+import { IOrderRepository } from '../../domains/repositories/IOrderRepository';
+import { prisma } from '../../../../libs/prisma';
+import { Prisma } from '@prisma/client';
+
+export class UpdateOrderTrackingInteractor
+  implements IUpdateOrderTrackingInteractor
+{
+  constructor(private readonly orderRepository: IOrderRepository) {}
+
+  async execute(orderId: number, trackingNumber: string): Promise<void> {
+    const order = await this.orderRepository.findById(orderId);
+    if (!order) {
+      throw new Error('Order not found');
+    }
+
+    // 物理商品が含まれているかチェック
+    const orderItems = await prisma.orderItems.findMany({
+      where: { orderId },
+      include: {
+        item: true,
+      },
+    });
+
+    type OrderItemWithItem = Prisma.OrderItemsGetPayload<{
+      include: { item: true };
+    }>;
+
+    const hasPhysicalItems = orderItems.some(
+      (orderItem: OrderItemWithItem) =>
+        orderItem.item && orderItem.item.type === 1,
+    );
+
+    if (!hasPhysicalItems) {
+      throw new Error('This order does not contain physical items');
+    }
+
+    // 既にSHIPPEDの場合はエラー
+    if (order.orderStatus === 'SHIPPED') {
+      throw new Error('This order has already been shipped');
+    }
+
+    // COMPLETEDでない場合はエラー
+    if (order.orderStatus !== 'COMPLETED') {
+      throw new Error('This order is not ready for shipping');
+    }
+
+    await this.orderRepository.updateTrackingNumber(orderId, trackingNumber);
+  }
+}

--- a/api/src/contexts/orders/admin/usecases/IUpdateOrderTrackingInteractor.ts
+++ b/api/src/contexts/orders/admin/usecases/IUpdateOrderTrackingInteractor.ts
@@ -1,0 +1,3 @@
+export interface IUpdateOrderTrackingInteractor {
+  execute(orderId: number, trackingNumber: string): Promise<void>;
+}

--- a/api/src/contexts/orders/domains/repositories/IOrderRepository.ts
+++ b/api/src/contexts/orders/domains/repositories/IOrderRepository.ts
@@ -44,4 +44,6 @@ export interface IOrderRepository {
     paymentId: string,
   ): Promise<OrderPaymentExternalId | null>;
   findOrdersNeedingShipping(): Promise<Order[]>;
+  findById(id: number): Promise<Order | null>;
+  updateTrackingNumber(id: number, trackingNumber: string): Promise<Order>;
 }

--- a/api/src/contexts/orders/infrastructures/repositories/OrderRepository.ts
+++ b/api/src/contexts/orders/infrastructures/repositories/OrderRepository.ts
@@ -155,6 +155,39 @@ export class OrderRepository implements IOrderRepository {
     return ordersWithPhysicalItems.map((order) => this.mapToOrder(order));
   }
 
+  async findById(id: number): Promise<Order | null> {
+    const order = await this.prisma.orders.findUnique({
+      where: { id },
+      include: {
+        orderItems: true,
+      },
+    });
+
+    if (!order) {
+      return null;
+    }
+
+    return this.mapToOrder(order);
+  }
+
+  async updateTrackingNumber(
+    id: number,
+    trackingNumber: string,
+  ): Promise<Order> {
+    const order = await this.prisma.orders.update({
+      where: { id },
+      data: {
+        trackingNumber,
+        orderStatus: OrderStatus.SHIPPED,
+      },
+      include: {
+        orderItems: true,
+      },
+    });
+
+    return this.mapToOrder(order);
+  }
+
   async createPaymentExternalId(
     data: CreateOrderPaymentExternalIdData,
   ): Promise<OrderPaymentExternalId> {

--- a/front/src/pages/admin/AdminOrderList.tsx
+++ b/front/src/pages/admin/AdminOrderList.tsx
@@ -1,5 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { getOrdersNeedingShipping } from '../../services/api/orders';
+import {
+  getOrdersNeedingShipping,
+  updateOrderTracking,
+} from '../../services/api/orders';
 import { GetRes } from '@shared/types/gets';
 
 type Order = GetRes['/admin/orders/shipping-needed']['orders'][0];
@@ -35,8 +38,22 @@ export const AdminOrderList: React.FC = () => {
       return;
     }
 
-    // TODO: バックエンドAPI実装後に有効化
-    alert('追跡番号を登録する機能は、バックエンドAPI実装後に有効化');
+    try {
+      setUpdating(true);
+      await updateOrderTracking(orderId, trackingNumber.trim());
+      // 注文リストを再取得
+      const response = await getOrdersNeedingShipping();
+      setOrders(response.orders);
+      setEditingOrderId(null);
+      setTrackingNumber('');
+      alert('追跡番号を登録しました');
+    } catch (err) {
+      alert(
+        err instanceof Error ? err.message : '追跡番号の登録に失敗しました',
+      );
+    } finally {
+      setUpdating(false);
+    }
   };
 
   if (loading) {

--- a/front/src/services/api/orders.ts
+++ b/front/src/services/api/orders.ts
@@ -20,3 +20,16 @@ export async function getOrdersNeedingShipping(): Promise<
   );
   return response.data;
 }
+
+export async function updateOrderTracking(
+  orderId: number,
+  trackingNumber: string,
+): Promise<void> {
+  const response = await apiClient.patch(`/admin/orders/${orderId}/tracking`, {
+    trackingNumber,
+  });
+  if (response.status !== 200) {
+    const error = response.data as { error?: string };
+    throw new Error(error.error || 'Failed to update tracking number');
+  }
+}


### PR DESCRIPTION
## 内容
フロントの配送管理画面から、追跡番号を入力し、注文データに番号を保存する。
保存と同時にステータスもSHIPPEDに変更する。

## 画面


https://github.com/user-attachments/assets/c13052c9-33dc-4df5-a2ac-a5938632a099

