### PR TITLE
お気に入り追加APIの作成

### DIFF
--- a/api/src/contexts/favorites/controllers/AddFavoriteController.ts
+++ b/api/src/contexts/favorites/controllers/AddFavoriteController.ts
@@ -1,0 +1,53 @@
+import express from 'express';
+import { PostReq, PostRes } from '@shared/types/posts';
+import { IAddFavoriteInteractor } from '../usecases/IAddFavoriteInteractor';
+import { AuthenticatedRequest } from '../../../middlewares';
+
+export class AddFavoriteController {
+  constructor(private readonly addFavoriteInteractor: IAddFavoriteInteractor) {}
+
+  async execute(
+    req: AuthenticatedRequest<PostReq['/favorites']>,
+    res: express.Response<PostRes['/favorites'] | { message: string }>,
+  ) {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ message: 'Authentication required' });
+      }
+
+      const { itemId } = req.body;
+
+      if (!itemId) {
+        return res.status(400).json({
+          message: 'itemId is required',
+        });
+      }
+
+      const favorite = await this.addFavoriteInteractor.execute(
+        req.user.userId,
+        itemId,
+      );
+
+      const responseFavorite = {
+        id: favorite.id,
+        userId: favorite.userId,
+        itemId: favorite.itemId,
+        createdAt: favorite.createdAt,
+      };
+
+      return res.status(201).json({ favorite: responseFavorite });
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        if (error.message === 'Favorite already exists for this item') {
+          return res.status(409).json({ message: error.message });
+        }
+        if (error.message === 'Item not found') {
+          return res.status(404).json({ message: error.message });
+        }
+      }
+
+      console.error('Error adding favorite:', error);
+      return res.status(500).json({ message: 'Internal server error' });
+    }
+  }
+}

--- a/api/src/contexts/favorites/domains/entities/Favorite.ts
+++ b/api/src/contexts/favorites/domains/entities/Favorite.ts
@@ -1,0 +1,7 @@
+export type Favorite = {
+  readonly id: number;
+  readonly userId: number;
+  readonly itemId: number;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+};

--- a/api/src/contexts/favorites/domains/repositories/IFavoriteRepository.ts
+++ b/api/src/contexts/favorites/domains/repositories/IFavoriteRepository.ts
@@ -1,0 +1,9 @@
+import { Favorite } from '../entities/Favorite';
+
+export interface IFavoriteRepository {
+  create(userId: number, itemId: number): Promise<Favorite>;
+  findByUserIdAndItemId(
+    userId: number,
+    itemId: number,
+  ): Promise<Favorite | null>;
+}

--- a/api/src/contexts/favorites/index.ts
+++ b/api/src/contexts/favorites/index.ts
@@ -1,0 +1,35 @@
+import express from 'express';
+import { AddFavoriteController } from './controllers/AddFavoriteController';
+import { AddFavoriteInteractor } from './interactors/AddFavoriteInteractor';
+import { FavoriteRepository } from './infrastructures/repositories/FavoriteRepository';
+import { ItemRepository } from '../items/infrastructures/repositories/ItemRepository';
+import { ItemImageRepository } from '../items/infrastructures/repositories/ItemImageRepository';
+import { LocalImageStorageAdapter } from '../items/infrastructures/adapters/LocalImageStorageAdapter';
+import { prisma } from '../../libs/prisma';
+import { verifyAccessToken } from '../../middlewares';
+import * as path from 'path';
+
+const favoritesRouter = express.Router();
+
+const favoriteRepository = new FavoriteRepository(prisma);
+const itemImageRepository = new ItemImageRepository(prisma);
+const uploadDir = path.join(process.cwd(), 'uploads', 'items');
+const imageStorageAdapter = new LocalImageStorageAdapter(uploadDir);
+const itemRepository = new ItemRepository(
+  prisma,
+  itemImageRepository,
+  imageStorageAdapter,
+);
+const addFavoriteInteractor = new AddFavoriteInteractor(
+  favoriteRepository,
+  itemRepository,
+);
+const addFavoriteController = new AddFavoriteController(addFavoriteInteractor);
+
+favoritesRouter.post(
+  '/',
+  verifyAccessToken,
+  addFavoriteController.execute.bind(addFavoriteController),
+);
+
+export { favoritesRouter };

--- a/api/src/contexts/favorites/infrastructures/repositories/FavoriteRepository.ts
+++ b/api/src/contexts/favorites/infrastructures/repositories/FavoriteRepository.ts
@@ -1,0 +1,50 @@
+import { PrismaClient } from '@prisma/client';
+import { IFavoriteRepository } from '../../domains/repositories/IFavoriteRepository';
+import { Favorite } from '../../domains/entities/Favorite';
+
+export class FavoriteRepository implements IFavoriteRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async create(userId: number, itemId: number): Promise<Favorite> {
+    const favorite = await this.prisma.favorites.create({
+      data: {
+        userId,
+        itemId,
+      },
+    });
+
+    return {
+      id: favorite.id,
+      userId: favorite.userId,
+      itemId: favorite.itemId,
+      createdAt: favorite.createdAt,
+      updatedAt: favorite.updatedAt,
+    };
+  }
+
+  async findByUserIdAndItemId(
+    userId: number,
+    itemId: number,
+  ): Promise<Favorite | null> {
+    const favorite = await this.prisma.favorites.findUnique({
+      where: {
+        userId_itemId: {
+          userId,
+          itemId,
+        },
+      },
+    });
+
+    if (!favorite) {
+      return null;
+    }
+
+    return {
+      id: favorite.id,
+      userId: favorite.userId,
+      itemId: favorite.itemId,
+      createdAt: favorite.createdAt,
+      updatedAt: favorite.updatedAt,
+    };
+  }
+}

--- a/api/src/contexts/favorites/interactors/AddFavoriteInteractor.ts
+++ b/api/src/contexts/favorites/interactors/AddFavoriteInteractor.ts
@@ -1,0 +1,29 @@
+import { IAddFavoriteInteractor } from '../usecases/IAddFavoriteInteractor';
+import { IFavoriteRepository } from '../domains/repositories/IFavoriteRepository';
+import { IItemRepository } from '../../items/domains/repositories/IItemRepository';
+import { Favorite } from '../domains/entities/Favorite';
+
+export class AddFavoriteInteractor implements IAddFavoriteInteractor {
+  constructor(
+    private readonly favoriteRepository: IFavoriteRepository,
+    private readonly itemRepository: IItemRepository,
+  ) {}
+
+  async execute(userId: number, itemId: number): Promise<Favorite> {
+    // 商品が存在するかチェック
+    const item = await this.itemRepository.findById(itemId);
+    if (!item) {
+      throw new Error('Item not found');
+    }
+
+    // 既存のお気に入りをチェック
+    const existingFavorite =
+      await this.favoriteRepository.findByUserIdAndItemId(userId, itemId);
+
+    if (existingFavorite) {
+      throw new Error('Favorite already exists for this item');
+    }
+
+    return await this.favoriteRepository.create(userId, itemId);
+  }
+}

--- a/api/src/contexts/favorites/usecases/IAddFavoriteInteractor.ts
+++ b/api/src/contexts/favorites/usecases/IAddFavoriteInteractor.ts
@@ -1,0 +1,5 @@
+import { Favorite } from '../domains/entities/Favorite';
+
+export interface IAddFavoriteInteractor {
+  execute(userId: number, itemId: number): Promise<Favorite>;
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -16,6 +16,7 @@ import { checkoutRouter } from './contexts/checkout';
 import { ordersRouter } from './contexts/orders';
 import { adminOrdersRouter } from './contexts/orders/admin';
 import { reviewsRouter } from './contexts/reviews';
+import { favoritesRouter } from './contexts/favorites';
 import { StripeWebhookController } from './contexts/checkout/controllers/StripeWebhookController';
 import { HandleStripeWebhookInteractor } from './contexts/checkout/interactors/HandleStripeWebhookInteractor';
 import { StripeAdapter } from './contexts/checkout/infrastructures/adapters/StripeAdapter';
@@ -88,6 +89,7 @@ app.use('/checkout', checkoutRouter);
 app.use('/orders', ordersRouter);
 app.use('/admin/orders', adminOrdersRouter);
 app.use('/reviews', reviewsRouter);
+app.use('/favorites', favoritesRouter);
 
 app.listen(8000, '0.0.0.0', () => {
   // eslint-disable-next-line no-console

--- a/shared/schemas/favorite.ts
+++ b/shared/schemas/favorite.ts
@@ -1,0 +1,6 @@
+export type Favorite = {
+  id: number;
+  userId: number;
+  itemId: number;
+  createdAt: Date;
+};

--- a/shared/types/posts.ts
+++ b/shared/types/posts.ts
@@ -2,6 +2,7 @@ import { User } from '../schemas/user';
 import { AdminItem } from '../schemas/item';
 import { CartItem } from '../schemas/cart';
 import { Review } from '../schemas/review';
+import { Favorite } from '../schemas/favorite';
 
 export type PostReq = {
   '/auth/login': {
@@ -33,6 +34,9 @@ export type PostReq = {
     body: string;
     rating: number;
   };
+  '/favorites': {
+    itemId: number;
+  };
 };
 
 export type PostRes = {
@@ -54,5 +58,8 @@ export type PostRes = {
   };
   '/reviews': {
     review: Review;
+  };
+  '/favorites': {
+    favorite: Favorite;
   };
 };


### PR DESCRIPTION
#129 

- [x] PR1: データベーススキーマとマイグレーション
- [ ] **今これ→PR2-1: バックエンドAPI実装（お気に入り追加）**
- [ ] PR2-2: バックエンドAPI実装（お気に入り削除）
- [ ] PR2-3: バックエンドAPI実装（お気に入り取得）
- [ ] PR2-4: 商品取得APIにお気に入りフラグを追加
- [ ] PR3: 型定義の追加（shared）
- [ ] PR4: フロントエンドAPIサービス実装
- [ ] PR5: 商品詳細画面のお気に入りボタン実装
- [ ] PR6: マイページのお気に入り表示実装
- [ ] PR7: お気に入り一覧ページ実装
- [ ] PR8: ヘッダーからのお気に入り一覧ページへのリンク実装