### PR TITLE
feat: add DELETE /favorites/:itemId API endpoint

### DIFF
--- a/api/src/contexts/favorites/controllers/RemoveFavoriteController.ts
+++ b/api/src/contexts/favorites/controllers/RemoveFavoriteController.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import { DeleteRes } from '@shared/types/delete';
+import { IRemoveFavoriteInteractor } from '../usecases/IRemoveFavoriteInteractor';
+import { AuthenticatedRequest } from '../../../middlewares';
+
+export class RemoveFavoriteController {
+  constructor(
+    private readonly removeFavoriteInteractor: IRemoveFavoriteInteractor,
+  ) {}
+
+  async execute(
+    req: AuthenticatedRequest<
+      Record<string, never>,
+      { itemId: string },
+      Record<string, never>
+    >,
+    res: express.Response<
+      DeleteRes['/favorites/:itemId'] | { message: string }
+    >,
+  ) {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ message: 'Authentication required' });
+      }
+
+      const itemId = parseInt(req.params.itemId);
+
+      if (isNaN(itemId)) {
+        return res.status(400).json({
+          message: 'Invalid item ID',
+        });
+      }
+
+      await this.removeFavoriteInteractor.execute(req.user.userId, itemId);
+
+      return res.status(200).json({ message: 'Favorite removed successfully' });
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        if (error.message === 'Favorite not found') {
+          return res.status(404).json({ message: error.message });
+        }
+      }
+
+      console.error('Error removing favorite:', error);
+      return res.status(500).json({ message: 'Internal server error' });
+    }
+  }
+}

--- a/api/src/contexts/favorites/domains/repositories/IFavoriteRepository.ts
+++ b/api/src/contexts/favorites/domains/repositories/IFavoriteRepository.ts
@@ -6,4 +6,5 @@ export interface IFavoriteRepository {
     userId: number,
     itemId: number,
   ): Promise<Favorite | null>;
+  delete(userId: number, itemId: number): Promise<void>;
 }

--- a/api/src/contexts/favorites/index.ts
+++ b/api/src/contexts/favorites/index.ts
@@ -1,6 +1,8 @@
 import express from 'express';
 import { AddFavoriteController } from './controllers/AddFavoriteController';
+import { RemoveFavoriteController } from './controllers/RemoveFavoriteController';
 import { AddFavoriteInteractor } from './interactors/AddFavoriteInteractor';
+import { RemoveFavoriteInteractor } from './interactors/RemoveFavoriteInteractor';
 import { FavoriteRepository } from './infrastructures/repositories/FavoriteRepository';
 import { ItemRepository } from '../items/infrastructures/repositories/ItemRepository';
 import { ItemImageRepository } from '../items/infrastructures/repositories/ItemImageRepository';
@@ -24,12 +26,24 @@ const addFavoriteInteractor = new AddFavoriteInteractor(
   favoriteRepository,
   itemRepository,
 );
+const removeFavoriteInteractor = new RemoveFavoriteInteractor(
+  favoriteRepository,
+);
 const addFavoriteController = new AddFavoriteController(addFavoriteInteractor);
+const removeFavoriteController = new RemoveFavoriteController(
+  removeFavoriteInteractor,
+);
 
 favoritesRouter.post(
   '/',
   verifyAccessToken,
   addFavoriteController.execute.bind(addFavoriteController),
+);
+
+favoritesRouter.delete(
+  '/:itemId',
+  verifyAccessToken,
+  removeFavoriteController.execute.bind(removeFavoriteController),
 );
 
 export { favoritesRouter };

--- a/api/src/contexts/favorites/infrastructures/repositories/FavoriteRepository.ts
+++ b/api/src/contexts/favorites/infrastructures/repositories/FavoriteRepository.ts
@@ -47,4 +47,15 @@ export class FavoriteRepository implements IFavoriteRepository {
       updatedAt: favorite.updatedAt,
     };
   }
+
+  async delete(userId: number, itemId: number): Promise<void> {
+    await this.prisma.favorites.delete({
+      where: {
+        userId_itemId: {
+          userId,
+          itemId,
+        },
+      },
+    });
+  }
 }

--- a/api/src/contexts/favorites/interactors/RemoveFavoriteInteractor.ts
+++ b/api/src/contexts/favorites/interactors/RemoveFavoriteInteractor.ts
@@ -1,0 +1,18 @@
+import { IRemoveFavoriteInteractor } from '../usecases/IRemoveFavoriteInteractor';
+import { IFavoriteRepository } from '../domains/repositories/IFavoriteRepository';
+
+export class RemoveFavoriteInteractor implements IRemoveFavoriteInteractor {
+  constructor(private readonly favoriteRepository: IFavoriteRepository) {}
+
+  async execute(userId: number, itemId: number): Promise<void> {
+    // お気に入りが存在するかチェック
+    const existingFavorite =
+      await this.favoriteRepository.findByUserIdAndItemId(userId, itemId);
+
+    if (!existingFavorite) {
+      throw new Error('Favorite not found');
+    }
+
+    await this.favoriteRepository.delete(userId, itemId);
+  }
+}

--- a/api/src/contexts/favorites/usecases/IRemoveFavoriteInteractor.ts
+++ b/api/src/contexts/favorites/usecases/IRemoveFavoriteInteractor.ts
@@ -1,0 +1,3 @@
+export interface IRemoveFavoriteInteractor {
+  execute(userId: number, itemId: number): Promise<void>;
+}

--- a/shared/types/delete.ts
+++ b/shared/types/delete.ts
@@ -1,9 +1,11 @@
 export type DeleteReq = {
   '/admin/items/:id': Record<string, never>;
   '/auth/resign': Record<string, never>;
+  '/favorites/:itemId': Record<string, never>;
 };
 
 export type DeleteRes = {
   '/admin/items/:id': { deleted: boolean };
   '/auth/resign': { success: boolean };
+  '/favorites/:itemId': { message: string };
 };


### PR DESCRIPTION
#129 

- [x] PR1: データベーススキーマとマイグレーション
- [x] PR2-1: バックエンドAPI実装（お気に入り追加）
- [ ] **今これ→PR2-2: バックエンドAPI実装（お気に入り削除）**
- [ ] PR2-3: バックエンドAPI実装（お気に入り取得）
- [ ] PR2-4: 商品取得APIにお気に入りフラグを追加
- [ ] PR3: 型定義の追加（shared）
- [ ] PR4: フロントエンドAPIサービス実装
- [ ] PR5: 商品詳細画面のお気に入りボタン実装
- [ ] PR6: マイページのお気に入り表示実装
- [ ] PR7: お気に入り一覧ページ実装
- [ ] PR8: ヘッダーからのお気に入り一覧ページへのリンク実装