### PR TITLE
feat: add GET /favorites API endpoint

### DIFF
--- a/api/src/contexts/favorites/controllers/GetFavoritesController.ts
+++ b/api/src/contexts/favorites/controllers/GetFavoritesController.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import { GetRes } from '@shared/types/gets';
+import { IGetFavoritesInteractor } from '../usecases/IGetFavoritesInteractor';
+import { AuthenticatedRequest } from '../../../middlewares';
+
+export class GetFavoritesController {
+  constructor(
+    private readonly getFavoritesInteractor: IGetFavoritesInteractor,
+  ) {}
+
+  async execute(
+    req: AuthenticatedRequest<Record<string, never>>,
+    res: express.Response<GetRes['/favorites'] | { message: string }>,
+  ) {
+    try {
+      if (!req.user) {
+        return res.status(401).json({ message: 'Authentication required' });
+      }
+
+      const result = await this.getFavoritesInteractor.execute(req.user.userId);
+
+      const responseFavorites = result.favorites.map((favorite) => ({
+        id: favorite.id,
+        userId: favorite.userId,
+        itemId: favorite.itemId,
+        createdAt: favorite.createdAt,
+        item: {
+          id: favorite.item.id,
+          name: favorite.item.name,
+          price: favorite.item.price,
+          images: favorite.item.images.map((image) => ({
+            id: image.id,
+            src: image.src,
+            order: image.order,
+          })),
+        },
+      }));
+
+      return res.status(200).json({
+        favorites: responseFavorites,
+        total: result.total,
+      });
+    } catch (error: unknown) {
+      console.error('Error fetching favorites:', error);
+      return res.status(500).json({ message: 'Internal server error' });
+    }
+  }
+}

--- a/api/src/contexts/favorites/domains/entities/FavoriteItem.ts
+++ b/api/src/contexts/favorites/domains/entities/FavoriteItem.ts
@@ -1,0 +1,21 @@
+export type ItemImage = {
+  readonly id: number;
+  readonly src: string;
+  readonly order: number;
+};
+
+export type Item = {
+  readonly id: number;
+  readonly name: string;
+  readonly price: number;
+  readonly images: readonly ItemImage[];
+};
+
+export type FavoriteItem = {
+  readonly id: number;
+  readonly userId: number;
+  readonly itemId: number;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+  readonly item: Item;
+};

--- a/api/src/contexts/favorites/domains/repositories/IFavoriteRepository.ts
+++ b/api/src/contexts/favorites/domains/repositories/IFavoriteRepository.ts
@@ -1,4 +1,10 @@
 import { Favorite } from '../entities/Favorite';
+import { FavoriteItem } from '../entities/FavoriteItem';
+
+export interface FindFavoritesResult {
+  readonly favorites: readonly FavoriteItem[];
+  readonly total: number;
+}
 
 export interface IFavoriteRepository {
   create(userId: number, itemId: number): Promise<Favorite>;
@@ -6,5 +12,6 @@ export interface IFavoriteRepository {
     userId: number,
     itemId: number,
   ): Promise<Favorite | null>;
+  findByUserId(userId: number): Promise<FindFavoritesResult>;
   delete(userId: number, itemId: number): Promise<void>;
 }

--- a/api/src/contexts/favorites/index.ts
+++ b/api/src/contexts/favorites/index.ts
@@ -1,8 +1,10 @@
 import express from 'express';
 import { AddFavoriteController } from './controllers/AddFavoriteController';
 import { RemoveFavoriteController } from './controllers/RemoveFavoriteController';
+import { GetFavoritesController } from './controllers/GetFavoritesController';
 import { AddFavoriteInteractor } from './interactors/AddFavoriteInteractor';
 import { RemoveFavoriteInteractor } from './interactors/RemoveFavoriteInteractor';
+import { GetFavoritesInteractor } from './interactors/GetFavoritesInteractor';
 import { FavoriteRepository } from './infrastructures/repositories/FavoriteRepository';
 import { ItemRepository } from '../items/infrastructures/repositories/ItemRepository';
 import { ItemImageRepository } from '../items/infrastructures/repositories/ItemImageRepository';
@@ -13,10 +15,14 @@ import * as path from 'path';
 
 const favoritesRouter = express.Router();
 
-const favoriteRepository = new FavoriteRepository(prisma);
 const itemImageRepository = new ItemImageRepository(prisma);
 const uploadDir = path.join(process.cwd(), 'uploads', 'items');
 const imageStorageAdapter = new LocalImageStorageAdapter(uploadDir);
+const favoriteRepository = new FavoriteRepository(
+  prisma,
+  itemImageRepository,
+  imageStorageAdapter,
+);
 const itemRepository = new ItemRepository(
   prisma,
   itemImageRepository,
@@ -29,9 +35,13 @@ const addFavoriteInteractor = new AddFavoriteInteractor(
 const removeFavoriteInteractor = new RemoveFavoriteInteractor(
   favoriteRepository,
 );
+const getFavoritesInteractor = new GetFavoritesInteractor(favoriteRepository);
 const addFavoriteController = new AddFavoriteController(addFavoriteInteractor);
 const removeFavoriteController = new RemoveFavoriteController(
   removeFavoriteInteractor,
+);
+const getFavoritesController = new GetFavoritesController(
+  getFavoritesInteractor,
 );
 
 favoritesRouter.post(
@@ -44,6 +54,12 @@ favoritesRouter.delete(
   '/:itemId',
   verifyAccessToken,
   removeFavoriteController.execute.bind(removeFavoriteController),
+);
+
+favoritesRouter.get(
+  '/',
+  verifyAccessToken,
+  getFavoritesController.execute.bind(getFavoritesController),
 );
 
 export { favoritesRouter };

--- a/api/src/contexts/favorites/infrastructures/repositories/FavoriteRepository.ts
+++ b/api/src/contexts/favorites/infrastructures/repositories/FavoriteRepository.ts
@@ -1,9 +1,19 @@
 import { PrismaClient } from '@prisma/client';
-import { IFavoriteRepository } from '../../domains/repositories/IFavoriteRepository';
+import {
+  IFavoriteRepository,
+  FindFavoritesResult,
+} from '../../domains/repositories/IFavoriteRepository';
 import { Favorite } from '../../domains/entities/Favorite';
+import { FavoriteItem, ItemImage } from '../../domains/entities/FavoriteItem';
+import { IItemImageRepository } from '../../../items/domains/repositories/IItemImageRepository';
+import { IImageStorageAdapter } from '../../../items/domains/adapters/IImageStorageAdapter';
 
 export class FavoriteRepository implements IFavoriteRepository {
-  constructor(private readonly prisma: PrismaClient) {}
+  constructor(
+    private readonly prisma: PrismaClient,
+    private readonly itemImageRepository: IItemImageRepository,
+    private readonly imageStorageAdapter: IImageStorageAdapter,
+  ) {}
 
   async create(userId: number, itemId: number): Promise<Favorite> {
     const favorite = await this.prisma.favorites.create({
@@ -57,5 +67,59 @@ export class FavoriteRepository implements IFavoriteRepository {
         },
       },
     });
+  }
+
+  async findByUserId(userId: number): Promise<FindFavoritesResult> {
+    const [favorites, total] = await Promise.all([
+      this.prisma.favorites.findMany({
+        where: {
+          userId,
+        },
+        include: {
+          item: true,
+        },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      }),
+      this.prisma.favorites.count({
+        where: {
+          userId,
+        },
+      }),
+    ]);
+
+    const favoritesWithItems: FavoriteItem[] = await Promise.all(
+      favorites.map(async (favorite): Promise<FavoriteItem> => {
+        // 画像情報を取得してURLに変換
+        const images = await this.itemImageRepository.findByItemId(
+          favorite.itemId,
+        );
+        const imagesWithUrl: ItemImage[] = images.map((image) => ({
+          id: image.id,
+          src: this.imageStorageAdapter.getUrl(image.src, favorite.itemId),
+          order: image.order,
+        }));
+
+        return {
+          id: favorite.id,
+          userId: favorite.userId,
+          itemId: favorite.itemId,
+          createdAt: favorite.createdAt,
+          updatedAt: favorite.updatedAt,
+          item: {
+            id: favorite.item.id,
+            name: favorite.item.name,
+            price: favorite.item.price,
+            images: imagesWithUrl,
+          },
+        };
+      }),
+    );
+
+    return {
+      favorites: favoritesWithItems,
+      total,
+    };
   }
 }

--- a/api/src/contexts/favorites/interactors/CheckFavoriteInteractor.ts
+++ b/api/src/contexts/favorites/interactors/CheckFavoriteInteractor.ts
@@ -1,0 +1,14 @@
+import { ICheckFavoriteInteractor } from '../usecases/ICheckFavoriteInteractor';
+import { IFavoriteRepository } from '../domains/repositories/IFavoriteRepository';
+
+export class CheckFavoriteInteractor implements ICheckFavoriteInteractor {
+  constructor(private readonly favoriteRepository: IFavoriteRepository) {}
+
+  async execute(userId: number, itemId: number): Promise<boolean> {
+    const favorite = await this.favoriteRepository.findByUserIdAndItemId(
+      userId,
+      itemId,
+    );
+    return favorite !== null;
+  }
+}

--- a/api/src/contexts/favorites/interactors/GetFavoritesInteractor.ts
+++ b/api/src/contexts/favorites/interactors/GetFavoritesInteractor.ts
@@ -1,0 +1,11 @@
+import { IGetFavoritesInteractor } from '../usecases/IGetFavoritesInteractor';
+import { IFavoriteRepository } from '../domains/repositories/IFavoriteRepository';
+import { FindFavoritesResult } from '../domains/repositories/IFavoriteRepository';
+
+export class GetFavoritesInteractor implements IGetFavoritesInteractor {
+  constructor(private readonly favoriteRepository: IFavoriteRepository) {}
+
+  async execute(userId: number): Promise<FindFavoritesResult> {
+    return await this.favoriteRepository.findByUserId(userId);
+  }
+}

--- a/api/src/contexts/favorites/usecases/ICheckFavoriteInteractor.ts
+++ b/api/src/contexts/favorites/usecases/ICheckFavoriteInteractor.ts
@@ -1,0 +1,3 @@
+export interface ICheckFavoriteInteractor {
+  execute(userId: number, itemId: number): Promise<boolean>;
+}

--- a/api/src/contexts/favorites/usecases/IGetFavoritesInteractor.ts
+++ b/api/src/contexts/favorites/usecases/IGetFavoritesInteractor.ts
@@ -1,0 +1,5 @@
+import { FindFavoritesResult } from '../domains/repositories/IFavoriteRepository';
+
+export interface IGetFavoritesInteractor {
+  execute(userId: number): Promise<FindFavoritesResult>;
+}

--- a/shared/types/gets.ts
+++ b/shared/types/gets.ts
@@ -96,4 +96,23 @@ export type GetRes = {
     total: number;
     averageRating: number;
   };
+  '/favorites': {
+    favorites: Array<{
+      id: number;
+      userId: number;
+      itemId: number;
+      createdAt: Date;
+      item: {
+        id: number;
+        name: string;
+        price: number;
+        images: Array<{
+          id: number;
+          src: string;
+          order: number;
+        }>;
+      };
+    }>;
+    total: number;
+  };
 };


### PR DESCRIPTION
#129 

- [x] PR1: データベーススキーマとマイグレーション
- [x] PR2-1: バックエンドAPI実装（お気に入り追加）
- [x] PR2-2: バックエンドAPI実装（お気に入り削除）
- [ ] **今これ→PR2-3: バックエンドAPI実装（お気に入り取得）**
- [ ] PR2-4: 商品取得APIにお気に入りフラグを追加
- [ ] PR3: 型定義の追加（shared）
- [ ] PR4: フロントエンドAPIサービス実装
- [ ] PR5: 商品詳細画面のお気に入りボタン実装
- [ ] PR6: マイページのお気に入り表示実装
- [ ] PR7: お気に入り一覧ページ実装
- [ ] PR8: ヘッダーからのお気に入り一覧ページへのリンク実装