### PR TITLE
商品関連のAPIにisFavoriteを追加

### DIFF
--- a/api/src/contexts/cart/index.ts
+++ b/api/src/contexts/cart/index.ts
@@ -8,6 +8,7 @@ import { CartItemRepository } from './infrastructures/repositories/CartItemRepos
 import { ItemRepository } from '../items/infrastructures/repositories/ItemRepository';
 import { ItemImageRepository } from '../items/infrastructures/repositories/ItemImageRepository';
 import { LocalImageStorageAdapter } from '../items/infrastructures/adapters/LocalImageStorageAdapter';
+import { FavoriteRepository } from '../favorites/infrastructures/repositories/FavoriteRepository';
 import { prisma } from '../../libs/prisma';
 import express from 'express';
 import { optionalVerifyAccessToken } from '../../middlewares';
@@ -20,10 +21,16 @@ const cartItemRepository = new CartItemRepository(prisma);
 const itemImageRepository = new ItemImageRepository(prisma);
 const uploadDir = path.join(process.cwd(), 'uploads', 'items');
 const imageStorageAdapter = new LocalImageStorageAdapter(uploadDir);
+const favoriteRepository = new FavoriteRepository(
+  prisma,
+  itemImageRepository,
+  imageStorageAdapter,
+);
 const itemRepository = new ItemRepository(
   prisma,
   itemImageRepository,
   imageStorageAdapter,
+  favoriteRepository,
 );
 const updateCartInteractor = new UpdateCartInteractor(
   cartRepository,

--- a/api/src/contexts/cart/interactors/UpdateCartInteractor.ts
+++ b/api/src/contexts/cart/interactors/UpdateCartInteractor.ts
@@ -17,9 +17,14 @@ export class UpdateCartInteractor implements IUpdateCartInteractor {
     items: Array<{ id: number; amount: number }>,
   ): Promise<Cart> {
     // 在庫チェック（amount > 0の場合のみ）
+    // カート更新処理ではお気に入り情報は不要
     for (const item of items) {
       if (item.amount > 0) {
-        const product = await this.itemRepository.findById(item.id);
+        const product = await this.itemRepository.findById(
+          item.id,
+          undefined,
+          undefined,
+        );
         if (!product) {
           throw new Error(`Item with id ${item.id} not found`);
         }

--- a/api/src/contexts/checkout/index.ts
+++ b/api/src/contexts/checkout/index.ts
@@ -5,6 +5,7 @@ import { CartRepository } from '../cart/infrastructures/repositories/CartReposit
 import { ItemRepository } from '../items/infrastructures/repositories/ItemRepository';
 import { ItemImageRepository } from '../items/infrastructures/repositories/ItemImageRepository';
 import { LocalImageStorageAdapter } from '../items/infrastructures/adapters/LocalImageStorageAdapter';
+import { FavoriteRepository } from '../favorites/infrastructures/repositories/FavoriteRepository';
 import { UserRepository } from '../users/infrastructures/repositories/UserRepository';
 import { OrderRepository } from '../orders/infrastructures/repositories/OrderRepository';
 import { prisma } from '../../libs/prisma';
@@ -18,10 +19,16 @@ const cartRepository = new CartRepository(prisma);
 const itemImageRepository = new ItemImageRepository(prisma);
 const uploadDir = path.join(process.cwd(), 'uploads', 'items');
 const imageStorageAdapter = new LocalImageStorageAdapter(uploadDir);
+const favoriteRepository = new FavoriteRepository(
+  prisma,
+  itemImageRepository,
+  imageStorageAdapter,
+);
 const itemRepository = new ItemRepository(
   prisma,
   itemImageRepository,
   imageStorageAdapter,
+  favoriteRepository,
 );
 const userRepository = new UserRepository(prisma);
 const orderRepository = new OrderRepository(prisma);

--- a/api/src/contexts/checkout/interactors/CreateCheckoutSessionInteractor.ts
+++ b/api/src/contexts/checkout/interactors/CreateCheckoutSessionInteractor.ts
@@ -55,7 +55,12 @@ export class CreateCheckoutSessionInteractor
     );
 
     for (const cartItem of cart.items) {
-      const item = await this.itemRepository.findById(cartItem.id);
+      // チェックアウト処理ではお気に入り情報は不要
+      const item = await this.itemRepository.findById(
+        cartItem.id,
+        undefined,
+        undefined,
+      );
       if (!item) {
         throw new Error(`Item with id ${cartItem.id} not found`);
       }

--- a/api/src/contexts/items/admin/index.ts
+++ b/api/src/contexts/items/admin/index.ts
@@ -11,6 +11,7 @@ import { GetItemInteractor } from './interactors/GetItemInteractor';
 import { ItemRepository } from '../infrastructures/repositories/ItemRepository';
 import { ItemImageRepository } from '../infrastructures/repositories/ItemImageRepository';
 import { LocalImageStorageAdapter } from '../infrastructures/adapters/LocalImageStorageAdapter';
+import { FavoriteRepository } from '../../favorites/infrastructures/repositories/FavoriteRepository';
 import { prisma } from '../../../libs/prisma';
 import express from 'express';
 import { verifyAccessToken, verifyAdmin } from '../../../middlewares';
@@ -21,10 +22,16 @@ const adminItemsRouter = express.Router();
 const itemImageRepository = new ItemImageRepository(prisma);
 const uploadDir = path.join(process.cwd(), 'uploads', 'items');
 const imageStorageAdapter = new LocalImageStorageAdapter(uploadDir);
+const favoriteRepository = new FavoriteRepository(
+  prisma,
+  itemImageRepository,
+  imageStorageAdapter,
+);
 const itemRepository = new ItemRepository(
   prisma,
   itemImageRepository,
   imageStorageAdapter,
+  favoriteRepository,
 );
 
 // 認証チェック

--- a/api/src/contexts/items/admin/interactors/CreateItemInteractor.ts
+++ b/api/src/contexts/items/admin/interactors/CreateItemInteractor.ts
@@ -45,8 +45,12 @@ export class CreateItemInteractor implements ICreateItemInteractor {
         undefined,
         finalDisplayStatus,
       );
-      // 更新後の商品を取得
-      const updatedItem = await this.itemRepository.findById(item.id);
+      // 更新後の商品を取得（管理者向けなのでお気に入り情報は不要）
+      const updatedItem = await this.itemRepository.findById(
+        item.id,
+        undefined,
+        undefined,
+      );
       if (updatedItem) {
         Object.assign(item, updatedItem);
       }

--- a/api/src/contexts/items/admin/interactors/GetItemInteractor.ts
+++ b/api/src/contexts/items/admin/interactors/GetItemInteractor.ts
@@ -5,9 +5,10 @@ import { Item } from '../../domains/entities/Item';
 export class GetItemInteractor implements IGetItemInteractor {
   constructor(private readonly itemRepository: IItemRepository) {}
 
-  async execute(id: number): Promise<Item | null> {
+  async execute(id: number, userId?: number): Promise<Item | null> {
     // 管理者向けなのでdisplayStatusフィルタリングなし
-    const item = await this.itemRepository.findById(id);
+    // 管理者向けではお気に入り情報は不要なのでuserIdは渡さない
+    const item = await this.itemRepository.findById(id, undefined, userId);
 
     return item;
   }

--- a/api/src/contexts/items/admin/interactors/UpdateItemInteractor.ts
+++ b/api/src/contexts/items/admin/interactors/UpdateItemInteractor.ts
@@ -30,8 +30,8 @@ export class UpdateItemInteractor implements IUpdateItemInteractor {
     files?: Express.Multer.File[],
     displayStatus?: DisplayStatus,
   ): Promise<{ item: Item; images: ItemImage[] } | null> {
-    // 商品の存在確認
-    const item = await this.itemRepository.findById(id);
+    // 商品の存在確認（管理者向けなのでお気に入り情報は不要）
+    const item = await this.itemRepository.findById(id, undefined, undefined);
     if (!item) {
       return null;
     }

--- a/api/src/contexts/items/controllers/GetItemController.ts
+++ b/api/src/contexts/items/controllers/GetItemController.ts
@@ -2,12 +2,13 @@ import express from 'express';
 import { GetRes } from '@shared/types/gets';
 import { IGetItemInteractor } from '../usecases/IGetItemInteractor';
 import { InventoryStatus } from '@shared/schemas/item';
+import { AuthenticatedRequest } from '../../../middlewares';
 
 export class GetItemController {
   constructor(private readonly getItemInteractor: IGetItemInteractor) {}
 
   async execute(
-    req: express.Request<{ id: string }>,
+    req: AuthenticatedRequest<Record<string, never>, { id: string }>,
     res: express.Response<GetRes['/items/:id'] | { message: string }>,
   ) {
     const itemId = parseInt(req.params.id);
@@ -16,7 +17,8 @@ export class GetItemController {
       return res.status(400).json({ message: 'Invalid item ID' });
     }
 
-    const item = await this.getItemInteractor.execute(itemId);
+    const userId = req.user?.userId;
+    const item = await this.getItemInteractor.execute(itemId, userId);
 
     if (!item) {
       return res.status(404).json({ message: 'Item not found' });
@@ -36,6 +38,7 @@ export class GetItemController {
         price: item.price,
         inventoryStatus,
         images: item.images,
+        isFavorite: item.isFavorite ?? null,
       },
     });
   }

--- a/api/src/contexts/items/controllers/GetItemsController.test.ts
+++ b/api/src/contexts/items/controllers/GetItemsController.test.ts
@@ -6,6 +6,7 @@ import { GetItemsInteractor } from '../interactors/GetItemsInteractor';
 import { ItemRepository } from '../infrastructures/repositories/ItemRepository';
 import { ItemImageRepository } from '../infrastructures/repositories/ItemImageRepository';
 import { LocalImageStorageAdapter } from '../infrastructures/adapters/LocalImageStorageAdapter';
+import { FavoriteRepository } from '../../favorites/infrastructures/repositories/FavoriteRepository';
 import { DisplayStatus } from '../domains/entities/Item';
 import { prismaTest } from '../../../libs/prisma-test';
 import { cleanDatabase } from '../../../tests/helpers/database';
@@ -20,10 +21,16 @@ describe('GetItemsController', () => {
     const itemImageRepository = new ItemImageRepository(prismaTest);
     const uploadDir = path.join(process.cwd(), 'uploads', 'items');
     const imageStorageAdapter = new LocalImageStorageAdapter(uploadDir);
+    const favoriteRepository = new FavoriteRepository(
+      prismaTest,
+      itemImageRepository,
+      imageStorageAdapter,
+    );
     const itemRepository = new ItemRepository(
       prismaTest,
       itemImageRepository,
       imageStorageAdapter,
+      favoriteRepository,
     );
     // 一般ユーザー向け: PUBLICな商品のみ取得
     const getItemsInteractor = new GetItemsInteractor(
@@ -151,6 +158,7 @@ describe('GetItemsController', () => {
         price: 5000,
         inventoryStatus: 'outOfStock',
         images: [],
+        isFavorite: null,
       });
     });
 

--- a/api/src/contexts/items/controllers/GetItemsController.ts
+++ b/api/src/contexts/items/controllers/GetItemsController.ts
@@ -2,15 +2,17 @@ import express from 'express';
 import { GetRes } from '@shared/types/gets';
 import { IGetItemsInteractor } from '../usecases/IGetItemsInteractor';
 import { InventoryStatus } from '@shared/schemas/item';
+import { AuthenticatedRequest } from '../../../middlewares';
 
 export class GetItemsController {
   constructor(private readonly getItemsInteractor: IGetItemsInteractor) {}
 
   async execute(
-    _req: express.Request<null>,
+    req: AuthenticatedRequest<Record<string, never>>,
     res: express.Response<GetRes['/items']>,
   ) {
-    const items = await this.getItemsInteractor.execute();
+    const userId = req.user?.userId;
+    const items = await this.getItemsInteractor.execute(userId);
 
     const responseItems = items.map((item) => ({
       id: item.id,
@@ -23,6 +25,7 @@ export class GetItemsController {
           ? InventoryStatus.IN_STOCK
           : InventoryStatus.OUT_OF_STOCK,
       images: item.images,
+      isFavorite: item.isFavorite ?? null,
     }));
 
     res.status(201).json({ items: responseItems });

--- a/api/src/contexts/items/controllers/SearchItemsController.ts
+++ b/api/src/contexts/items/controllers/SearchItemsController.ts
@@ -6,6 +6,7 @@ import {
   SearchSortType,
   InventoryStatus,
 } from '@shared/schemas/item';
+import { AuthenticatedRequest } from '../../../middlewares';
 
 type SearchParamsResult =
   | { success: true; params: SearchItemsParams }
@@ -15,7 +16,7 @@ export class SearchItemsController {
   constructor(private readonly searchItemsInteractor: ISearchItemsInteractor) {}
 
   async execute(
-    req: express.Request,
+    req: AuthenticatedRequest<Record<string, never>>,
     res: express.Response<GetRes['/items/search'] | { message: string }>,
   ) {
     const result = this.buildSearchParams(req.query);
@@ -24,7 +25,11 @@ export class SearchItemsController {
       return res.status(400).json({ message: result.error });
     }
 
-    const items = await this.searchItemsInteractor.execute(result.params);
+    const userId = req.user?.userId;
+    const items = await this.searchItemsInteractor.execute(
+      result.params,
+      userId,
+    );
 
     const responseItems = items.map((item) => ({
       id: item.id,
@@ -37,6 +42,7 @@ export class SearchItemsController {
           ? InventoryStatus.IN_STOCK
           : InventoryStatus.OUT_OF_STOCK,
       images: item.images,
+      isFavorite: item.isFavorite ?? null,
     }));
 
     res.status(200).json({ items: responseItems });

--- a/api/src/contexts/items/domains/entities/Item.ts
+++ b/api/src/contexts/items/domains/entities/Item.ts
@@ -20,4 +20,5 @@ export type Item = {
   readonly images: ItemImage[];
   readonly createdAt: Date;
   readonly updatedAt: Date;
+  readonly isFavorite?: boolean | null;
 };

--- a/api/src/contexts/items/domains/repositories/IItemRepository.ts
+++ b/api/src/contexts/items/domains/repositories/IItemRepository.ts
@@ -2,9 +2,13 @@ import { DisplayStatus, Item } from '../entities/Item';
 import { ItemQuery } from './ItemQuery';
 
 export interface IItemRepository {
-  findAll(displayStatus?: DisplayStatus): Promise<Item[]>;
-  find(query?: ItemQuery): Promise<Item[]>;
-  findById(id: number, displayStatus?: DisplayStatus): Promise<Item | null>;
+  findAll(displayStatus?: DisplayStatus, userId?: number): Promise<Item[]>;
+  find(query?: ItemQuery, userId?: number): Promise<Item[]>;
+  findById(
+    id: number,
+    displayStatus?: DisplayStatus,
+    userId?: number,
+  ): Promise<Item | null>;
   create(name: string, description: string, type: number): Promise<Item>;
   update(
     id: number,

--- a/api/src/contexts/items/index.ts
+++ b/api/src/contexts/items/index.ts
@@ -7,8 +7,10 @@ import { SearchItemsInteractor } from './interactors/SearchItemsInteractor';
 import { ItemRepository } from './infrastructures/repositories/ItemRepository';
 import { ItemImageRepository } from './infrastructures/repositories/ItemImageRepository';
 import { LocalImageStorageAdapter } from './infrastructures/adapters/LocalImageStorageAdapter';
+import { FavoriteRepository } from '../favorites/infrastructures/repositories/FavoriteRepository';
 import { DisplayStatus } from './domains/entities/Item';
 import { prisma } from '../../libs/prisma';
+import { optionalVerifyAccessToken } from '../../middlewares';
 import express from 'express';
 import * as path from 'path';
 
@@ -17,10 +19,16 @@ const itemsRouter = express.Router();
 const itemImageRepository = new ItemImageRepository(prisma);
 const uploadDir = path.join(process.cwd(), 'uploads', 'items');
 const imageStorageAdapter = new LocalImageStorageAdapter(uploadDir);
+const favoriteRepository = new FavoriteRepository(
+  prisma,
+  itemImageRepository,
+  imageStorageAdapter,
+);
 const itemRepository = new ItemRepository(
   prisma,
   itemImageRepository,
   imageStorageAdapter,
+  favoriteRepository,
 );
 // 一般ユーザー向け: PUBLICな商品のみ取得
 const getItemsInteractor = new GetItemsInteractor(
@@ -33,11 +41,20 @@ const getItemController = new GetItemController(getItemInteractor);
 const searchItemsInteractor = new SearchItemsInteractor(itemRepository);
 const searchItemsController = new SearchItemsController(searchItemsInteractor);
 
-itemsRouter.get('/', getItemsController.execute.bind(getItemsController));
+itemsRouter.get(
+  '/',
+  optionalVerifyAccessToken,
+  getItemsController.execute.bind(getItemsController),
+);
 itemsRouter.get(
   '/search',
+  optionalVerifyAccessToken,
   searchItemsController.execute.bind(searchItemsController),
 );
-itemsRouter.get('/:id', getItemController.execute.bind(getItemController));
+itemsRouter.get(
+  '/:id',
+  optionalVerifyAccessToken,
+  getItemController.execute.bind(getItemController),
+);
 
 export { itemsRouter };

--- a/api/src/contexts/items/infrastructures/repositories/ItemRepository.ts
+++ b/api/src/contexts/items/infrastructures/repositories/ItemRepository.ts
@@ -4,15 +4,20 @@ import { ItemQuery } from '../../domains/repositories/ItemQuery';
 import { DisplayStatus, Item } from '../../domains/entities/Item';
 import { IItemImageRepository } from '../../domains/repositories/IItemImageRepository';
 import { IImageStorageAdapter } from '../../domains/adapters/IImageStorageAdapter';
+import { IFavoriteRepository } from '../../../favorites/domains/repositories/IFavoriteRepository';
 
 export class ItemRepository implements IItemRepository {
   constructor(
     private readonly prisma: PrismaClient,
     private readonly itemImageRepository: IItemImageRepository,
     private readonly imageStorageAdapter: IImageStorageAdapter,
+    private readonly favoriteRepository?: IFavoriteRepository,
   ) {}
 
-  async findAll(displayStatus?: DisplayStatus): Promise<Item[]> {
+  async findAll(
+    displayStatus?: DisplayStatus,
+    userId?: number,
+  ): Promise<Item[]> {
     const items = await this.prisma.items.findMany({
       where: displayStatus ? { displayStatus } : undefined,
       orderBy: { createdAt: 'desc' },
@@ -30,6 +35,16 @@ export class ItemRepository implements IItemRepository {
           src: this.imageStorageAdapter.getUrl(image.src, item.id),
         }));
 
+        // お気に入り情報を取得
+        let isFavorite: boolean | null = null;
+        if (userId && this.favoriteRepository) {
+          const favorite = await this.favoriteRepository.findByUserIdAndItemId(
+            userId,
+            item.id,
+          );
+          isFavorite = favorite !== null;
+        }
+
         return {
           id: item.id,
           name: item.name,
@@ -45,12 +60,13 @@ export class ItemRepository implements IItemRepository {
           images: imagesWithUrl,
           createdAt: item.createdAt,
           updatedAt: item.updatedAt,
+          isFavorite,
         };
       }),
     );
   }
 
-  async find(query?: ItemQuery): Promise<Item[]> {
+  async find(query?: ItemQuery, userId?: number): Promise<Item[]> {
     const prismaQuery = this.buildPrismaQuery(query);
     const items = await this.prisma.items.findMany({
       ...prismaQuery,
@@ -67,6 +83,16 @@ export class ItemRepository implements IItemRepository {
           src: this.imageStorageAdapter.getUrl(image.src, item.id),
         }));
 
+        // お気に入り情報を取得
+        let isFavorite: boolean | null = null;
+        if (userId && this.favoriteRepository) {
+          const favorite = await this.favoriteRepository.findByUserIdAndItemId(
+            userId,
+            item.id,
+          );
+          isFavorite = favorite !== null;
+        }
+
         return {
           id: item.id,
           name: item.name,
@@ -82,6 +108,7 @@ export class ItemRepository implements IItemRepository {
           images: imagesWithUrl,
           createdAt: item.createdAt,
           updatedAt: item.updatedAt,
+          isFavorite,
         };
       }),
     );
@@ -247,6 +274,7 @@ export class ItemRepository implements IItemRepository {
   async findById(
     id: number,
     displayStatus?: DisplayStatus,
+    userId?: number,
   ): Promise<Item | null> {
     const item = await this.prisma.items.findFirst({
       where: { id, displayStatus },
@@ -266,6 +294,16 @@ export class ItemRepository implements IItemRepository {
       src: this.imageStorageAdapter.getUrl(image.src, item.id),
     }));
 
+    // お気に入り情報を取得
+    let isFavorite: boolean | null = null;
+    if (userId && this.favoriteRepository) {
+      const favorite = await this.favoriteRepository.findByUserIdAndItemId(
+        userId,
+        item.id,
+      );
+      isFavorite = favorite !== null;
+    }
+
     return {
       id: item.id,
       name: item.name,
@@ -281,6 +319,7 @@ export class ItemRepository implements IItemRepository {
       images: imagesWithUrl,
       createdAt: item.createdAt,
       updatedAt: item.updatedAt,
+      isFavorite,
     };
   }
 

--- a/api/src/contexts/items/interactors/GetItemInteractor.ts
+++ b/api/src/contexts/items/interactors/GetItemInteractor.ts
@@ -5,8 +5,12 @@ import { DisplayStatus, Item } from '../domains/entities/Item';
 export class GetItemInteractor implements IGetItemInteractor {
   constructor(private readonly itemRepository: IItemRepository) {}
 
-  async execute(id: number): Promise<Item | null> {
-    const item = await this.itemRepository.findById(id, DisplayStatus.PUBLIC);
+  async execute(id: number, userId?: number): Promise<Item | null> {
+    const item = await this.itemRepository.findById(
+      id,
+      DisplayStatus.PUBLIC,
+      userId,
+    );
 
     return item;
   }

--- a/api/src/contexts/items/interactors/GetItemsInteractor.ts
+++ b/api/src/contexts/items/interactors/GetItemsInteractor.ts
@@ -8,9 +8,9 @@ export class GetItemsInteractor implements IGetItemsInteractor {
     private readonly displayStatus?: DisplayStatus,
   ) {}
 
-  async execute(): Promise<Item[]> {
+  async execute(userId?: number): Promise<Item[]> {
     // displayStatusが指定されていない場合は全ての商品を取得（管理者向け）
     // displayStatusが指定されている場合はその条件でフィルタリング（一般ユーザー向け）
-    return await this.itemRepository.findAll(this.displayStatus);
+    return await this.itemRepository.findAll(this.displayStatus, userId);
   }
 }

--- a/api/src/contexts/items/interactors/SearchItemsInteractor.ts
+++ b/api/src/contexts/items/interactors/SearchItemsInteractor.ts
@@ -7,9 +7,9 @@ import { Item } from '../domains/entities/Item';
 export class SearchItemsInteractor implements ISearchItemsInteractor {
   constructor(private readonly itemRepository: IItemRepository) {}
 
-  async execute(params: SearchItemsParams): Promise<Item[]> {
+  async execute(params: SearchItemsParams, userId?: number): Promise<Item[]> {
     const query = this.buildQuery(params);
-    return await this.itemRepository.find(query);
+    return await this.itemRepository.find(query, userId);
   }
 
   private buildQuery(params: SearchItemsParams): ItemQuery {

--- a/api/src/contexts/items/usecases/IGetItemInteractor.ts
+++ b/api/src/contexts/items/usecases/IGetItemInteractor.ts
@@ -1,5 +1,5 @@
 import { Item } from '../domains/entities/Item';
 
 export interface IGetItemInteractor {
-  execute(id: number): Promise<Item | null>;
+  execute(id: number, userId?: number): Promise<Item | null>;
 }

--- a/api/src/contexts/items/usecases/IGetItemsInteractor.ts
+++ b/api/src/contexts/items/usecases/IGetItemsInteractor.ts
@@ -1,5 +1,5 @@
 import { Item } from '../domains/entities/Item';
 
 export interface IGetItemsInteractor {
-  execute(): Promise<Item[]>;
+  execute(userId?: number): Promise<Item[]>;
 }

--- a/api/src/contexts/items/usecases/ISearchItemsInteractor.ts
+++ b/api/src/contexts/items/usecases/ISearchItemsInteractor.ts
@@ -2,5 +2,5 @@ import { Item } from '../domains/entities/Item';
 import { SearchItemsParams } from '@shared/schemas/item';
 
 export interface ISearchItemsInteractor {
-  execute(params: SearchItemsParams): Promise<Item[]>;
+  execute(params: SearchItemsParams, userId?: number): Promise<Item[]>;
 }

--- a/shared/schemas/item.ts
+++ b/shared/schemas/item.ts
@@ -30,6 +30,7 @@ export type Item = {
   price: number;
   inventoryStatus: InventoryStatus;
   images: ItemImage[];
+  isFavorite: boolean | null;
 };
 
 export type ItemDetail = {
@@ -40,6 +41,7 @@ export type ItemDetail = {
   price: number;
   inventoryStatus: InventoryStatus;
   images: ItemImage[];
+  isFavorite: boolean | null;
 };
 
 export const DisplayStatus = {


### PR DESCRIPTION
#129 

- [x] PR1: データベーススキーマとマイグレーション
- [x] PR2-1: バックエンドAPI実装（お気に入り追加）
- [x] PR2-2: バックエンドAPI実装（お気に入り削除）
- [x] PR2-3: バックエンドAPI実装（お気に入り取得）
- [ ] **今これ→PR2-4: 商品取得APIにお気に入りフラグを追加**
- [ ] PR3: 型定義の追加（shared）
- [ ] PR4: フロントエンドAPIサービス実装
- [ ] PR5: 商品詳細画面のお気に入りボタン実装
- [ ] PR6: マイページのお気に入り表示実装
- [ ] PR7: お気に入り一覧ページ実装
- [ ] PR8: ヘッダーからのお気に入り一覧ページへのリンク実装