### PR TITLE
お気に入りの型定義をsharedに追加

### DIFF
--- a/shared/schemas/favorite.ts
+++ b/shared/schemas/favorite.ts
@@ -4,3 +4,24 @@ export type Favorite = {
   itemId: number;
   createdAt: Date;
 };
+
+export type FavoriteItemImage = {
+  id: number;
+  src: string;
+  order: number;
+};
+
+export type FavoriteItemDetail = {
+  id: number;
+  name: string;
+  price: number;
+  images: FavoriteItemImage[];
+};
+
+export type FavoriteItem = {
+  id: number;
+  userId: number;
+  itemId: number;
+  createdAt: Date;
+  item: FavoriteItemDetail;
+};

--- a/shared/types/gets.ts
+++ b/shared/types/gets.ts
@@ -2,6 +2,7 @@ import { Item, ItemDetail, AdminItem, AdminItemDetail } from '../schemas/item';
 import { User } from '../schemas/user';
 import { CartItem } from '../schemas/cart';
 import { Review } from '../schemas/review';
+import { FavoriteItem } from '../schemas/favorite';
 
 export type GetRes = {
   '/items': {
@@ -97,22 +98,7 @@ export type GetRes = {
     averageRating: number;
   };
   '/favorites': {
-    favorites: Array<{
-      id: number;
-      userId: number;
-      itemId: number;
-      createdAt: Date;
-      item: {
-        id: number;
-        name: string;
-        price: number;
-        images: Array<{
-          id: number;
-          src: string;
-          order: number;
-        }>;
-      };
-    }>;
+    favorites: FavoriteItem[];
     total: number;
   };
 };


### PR DESCRIPTION
#129 

- [x] PR1: データベーススキーマとマイグレーション
- [x] PR2-1: バックエンドAPI実装（お気に入り追加）
- [x] PR2-2: バックエンドAPI実装（お気に入り削除）
- [x] PR2-3: バックエンドAPI実装（お気に入り取得）
- [x] PR2-4: 商品取得APIにお気に入りフラグを追加
- [ ] **今これ→PR3: 型定義の追加（shared）**
- [ ] PR4: フロントエンドAPIサービス実装
- [ ] PR5: 商品詳細画面のお気に入りボタン実装
- [ ] PR6: マイページのお気に入り表示実装
- [ ] PR7: お気に入り一覧ページ実装
- [ ] PR8: ヘッダーからのお気に入り一覧ページへのリンク実装