### PR TITLE
お気に入り関連のAPIサービス実装

### DIFF
--- a/front/src/services/api/favorites.ts
+++ b/front/src/services/api/favorites.ts
@@ -1,0 +1,38 @@
+import { apiClient } from './apiClient';
+import { GetRes } from '@shared/types/gets';
+import { PostReq, PostRes } from '@shared/types/posts';
+import { DeleteRes } from '@shared/types/delete';
+
+/**
+ * お気に入り一覧を取得
+ */
+export async function getFavorites(): Promise<GetRes['/favorites']> {
+  const response = await apiClient.get<GetRes['/favorites']>('/favorites');
+  return response.data;
+}
+
+/**
+ * お気に入りに追加
+ */
+export async function addFavorite(
+  itemId: number,
+): Promise<PostRes['/favorites']> {
+  const data: PostReq['/favorites'] = { itemId };
+  const response = await apiClient.post<PostRes['/favorites']>(
+    '/favorites',
+    data,
+  );
+  return response.data;
+}
+
+/**
+ * お気に入りから削除
+ */
+export async function removeFavorite(
+  itemId: number,
+): Promise<DeleteRes['/favorites/:itemId']> {
+  const response = await apiClient.delete<DeleteRes['/favorites/:itemId']>(
+    `/favorites/${itemId}`,
+  );
+  return response.data;
+}


### PR DESCRIPTION
#129 

- [x] PR1: データベーススキーマとマイグレーション
- [x] PR2-1: バックエンドAPI実装（お気に入り追加）
- [x] PR2-2: バックエンドAPI実装（お気に入り削除）
- [x] PR2-3: バックエンドAPI実装（お気に入り取得）
- [x] PR2-4: 商品取得APIにお気に入りフラグを追加
- [x] PR3: 型定義の追加（shared）
- [ ] **今これ→PR4: フロントエンドAPIサービス実装**
- [ ] PR5: 商品詳細画面のお気に入りボタン実装
- [ ] PR6: マイページのお気に入り表示実装
- [ ] PR7: お気に入り一覧ページ実装
- [ ] PR8: ヘッダーからのお気に入り一覧ページへのリンク実装