### PR TITLE
商品詳細画面でお気に入りできるようにする

### DIFF
--- a/front/src/components/product/ActionButtons.tsx
+++ b/front/src/components/product/ActionButtons.tsx
@@ -1,18 +1,23 @@
 import React from 'react';
 import { HeartIcon } from '@heroicons/react/24/outline';
+import { HeartIcon as HeartIconSolid } from '@heroicons/react/24/solid';
 
 export interface ActionButtonsProps {
   isOutOfStock: boolean;
   isAddingToCart: boolean;
   onAddToCart: () => void;
-  onAddToWishlist: () => void;
+  onToggleFavorite: () => void;
+  isFavorite: boolean;
+  isTogglingFavorite: boolean;
 }
 
 export const ActionButtons: React.FC<ActionButtonsProps> = ({
   isOutOfStock,
   isAddingToCart,
   onAddToCart,
-  onAddToWishlist,
+  onToggleFavorite,
+  isFavorite,
+  isTogglingFavorite,
 }) => (
   <div className="flex gap-3">
     <button
@@ -27,11 +32,19 @@ export const ActionButtons: React.FC<ActionButtonsProps> = ({
           : 'カートに追加'}
     </button>
     <button
-      onClick={onAddToWishlist}
-      className="px-4 py-4 border border-gray-300 rounded-lg hover:border-gray-400 hover:bg-gray-50 transition-colors flex items-center justify-center"
-      aria-label="ウィッシュリストに追加"
+      onClick={onToggleFavorite}
+      className={`px-4 py-4 border rounded-lg transition-colors flex items-center justify-center cursor-pointer ${
+        isFavorite
+          ? 'border-red-300 bg-red-50 hover:bg-red-100'
+          : 'border-gray-300 hover:border-gray-400 hover:bg-gray-50'
+      } ${isTogglingFavorite ? 'opacity-50' : ''}`}
+      aria-label={isFavorite ? 'お気に入りから削除' : 'お気に入りに追加'}
     >
-      <HeartIcon className="w-5 h-5 text-gray-500" />
+      {isFavorite ? (
+        <HeartIconSolid className="w-5 h-5 text-red-500" />
+      ) : (
+        <HeartIcon className="w-5 h-5 text-gray-500" />
+      )}
     </button>
   </div>
 );

--- a/front/src/pages/ProductDetail.tsx
+++ b/front/src/pages/ProductDetail.tsx
@@ -1,9 +1,11 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { useParams } from 'react-router';
+import { useParams, useNavigate } from 'react-router';
 import { Item } from '@shared/schemas/item';
 import { getItem, InventoryStatus } from '../services/api/items';
 import { addToCart } from '../services/api/cart';
+import { addFavorite, removeFavorite } from '../services/api/favorites';
 import { useCart } from '../contexts/CartContext';
+import { useUser } from '../contexts/UserContext';
 import { BackLink } from '../components/product/BackLink';
 import { LoadingState } from '../components/product/LoadingState';
 import { ErrorState } from '../components/product/ErrorState';
@@ -22,7 +24,9 @@ type ProductDetailState = {
 
 export const ProductDetail: React.FC = () => {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
   const { refreshCart } = useCart();
+  const { isLoggedIn } = useUser();
   const [state, setState] = useState<ProductDetailState>({
     item: null,
     isLoading: true,
@@ -30,6 +34,7 @@ export const ProductDetail: React.FC = () => {
   });
   const [quantity, setQuantity] = useState(MIN_QUANTITY);
   const [isAddingToCart, setIsAddingToCart] = useState(false);
+  const [isTogglingFavorite, setIsTogglingFavorite] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
 
   const itemId = useMemo(() => {
@@ -117,10 +122,51 @@ export const ProductDetail: React.FC = () => {
     }
   }, [state.item, quantity, refreshCart]);
 
-  const handleAddToWishlist = useCallback((): void => {
-    // TODO: ウィッシュリスト機能の実装
-    console.log('Add to wishlist:', state.item?.id);
-  }, [state.item?.id]);
+  const handleToggleFavorite = useCallback(async (): Promise<void> => {
+    if (!state.item) return;
+
+    if (isTogglingFavorite) return;
+
+    // ログインしていない場合はログインページにリダイレクト
+    if (!isLoggedIn() || state.item.isFavorite === null) {
+      navigate('/auth/login');
+      return;
+    }
+
+    setIsTogglingFavorite(true);
+    try {
+      if (state.item.isFavorite) {
+        await removeFavorite(state.item.id);
+        setState((prev) => {
+          if (!prev.item) return prev;
+          return {
+            ...prev,
+            item: {
+              ...prev.item,
+              isFavorite: false,
+            },
+          };
+        });
+      } else {
+        await addFavorite(state.item.id);
+        setState((prev) => {
+          if (!prev.item) return prev;
+          return {
+            ...prev,
+            item: {
+              ...prev.item,
+              isFavorite: true,
+            },
+          };
+        });
+      }
+    } catch (err) {
+      console.error('Failed to toggle favorite:', err);
+      alert('お気に入りの操作に失敗しました');
+    } finally {
+      setIsTogglingFavorite(false);
+    }
+  }, [state.item, isLoggedIn, navigate]);
 
   const isOutOfStock = useMemo(
     () => state.item?.inventoryStatus === InventoryStatus.OUT_OF_STOCK,
@@ -254,7 +300,9 @@ export const ProductDetail: React.FC = () => {
             isOutOfStock={isOutOfStock}
             isAddingToCart={isAddingToCart}
             onAddToCart={handleAddToCart}
-            onAddToWishlist={handleAddToWishlist}
+            onToggleFavorite={handleToggleFavorite}
+            isFavorite={state.item.isFavorite ?? false}
+            isTogglingFavorite={isTogglingFavorite}
           />
 
           {/* 説明文 */}


### PR DESCRIPTION
#129 

- [x] PR1: データベーススキーマとマイグレーション
- [x] PR2-1: バックエンドAPI実装（お気に入り追加）
- [x] PR2-2: バックエンドAPI実装（お気に入り削除）
- [x] PR2-3: バックエンドAPI実装（お気に入り取得）
- [x] PR2-4: 商品取得APIにお気に入りフラグを追加
- [x] PR3: 型定義の追加（shared）
- [x] PR4: フロントエンドAPIサービス実装
- [ ] **今これ→PR5: 商品詳細画面のお気に入りボタン実装**
- [ ] PR6: マイページのお気に入り表示実装
- [ ] PR7: お気に入り一覧ページ実装
- [ ] PR8: ヘッダーからのお気に入り一覧ページへのリンク実装


https://github.com/user-attachments/assets/72214378-383f-45f1-8024-eff8279d3329

