### PR TITLE
マイページにお気に入りを表示する

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from 'express';
 import { config } from 'dotenv';
 import cors from 'cors';
 import cookieParser from 'cookie-parser';
+import * as path from 'path';
 
 // Load environment variables from .env file
 config();
@@ -35,6 +36,12 @@ app.use(
 );
 
 app.use(cookieParser());
+
+// 静的ファイル配信: 画像ファイルを /images/items パスで配信
+app.use(
+  '/images/items',
+  express.static(path.join(process.cwd(), 'uploads', 'items')),
+);
 
 // Webhookエンドポイントは express.json() の適用前に配置する必要がある
 // Stripeの署名検証には生のリクエストボディが必要

--- a/front/src/components/user/FavoritesPreview.tsx
+++ b/front/src/components/user/FavoritesPreview.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import { getFavorites } from '../../services/api/favorites';
+import { FavoriteItem } from '@shared/schemas/favorite';
+import { API_BASE_URL } from '../../services/api/config';
+
+const FAVORITES_PREVIEW_LIMIT = 3;
+
+export const FavoritesPreview: React.FC = () => {
+  const navigate = useNavigate();
+  const [favorites, setFavorites] = useState<FavoriteItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchFavorites = async () => {
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await getFavorites();
+        setFavorites(response.favorites);
+        setTotal(response.total);
+      } catch (err) {
+        console.error('Failed to fetch favorites:', err);
+        setError('お気に入りの取得に失敗しました');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchFavorites();
+  }, []);
+
+  if (loading) {
+    return <div className="text-gray-500">読み込み中...</div>;
+  }
+
+  if (error) {
+    return <div className="text-red-500">{error}</div>;
+  }
+
+  if (favorites.length === 0) {
+    return <div className="text-gray-500">お気に入りがありません</div>;
+  }
+
+  const previewFavorites = favorites.slice(0, FAVORITES_PREVIEW_LIMIT);
+  const hasMoreFavorites = total > FAVORITES_PREVIEW_LIMIT;
+
+  return (
+    <div>
+      <div className="grid grid-cols-3 gap-4 mb-4">
+        {previewFavorites.map((favorite) => {
+          const firstImage = favorite.item.images[0];
+          const imageUrl = firstImage
+            ? `${API_BASE_URL}${firstImage.src}`
+            : null;
+
+          return (
+            <div
+              key={favorite.id}
+              className="cursor-pointer"
+              onClick={() => navigate(`/products/${favorite.itemId}`)}
+            >
+              <div className="aspect-square bg-gray-100 rounded-lg overflow-hidden mb-2">
+                {imageUrl ? (
+                  <img
+                    src={imageUrl}
+                    alt={favorite.item.name}
+                    className="w-full h-full object-cover"
+                    onError={(e) => {
+                      const target = e.target as HTMLImageElement;
+                      target.style.display = 'none';
+                      if (target.parentElement) {
+                        target.parentElement.innerHTML =
+                          '<span class="text-gray-500 text-sm flex items-center justify-center h-full">画像なし</span>';
+                      }
+                    }}
+                  />
+                ) : (
+                  <div className="w-full h-full flex items-center justify-center">
+                    <span className="text-gray-500 text-sm">画像なし</span>
+                  </div>
+                )}
+              </div>
+              <p className="text-sm text-gray-700 truncate">
+                {favorite.item.name}
+              </p>
+              <p className="text-sm font-bold text-gray-900">
+                ¥{favorite.item.price.toLocaleString()}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+      {hasMoreFavorites && (
+        <div className="text-center">
+          <button
+            onClick={() => navigate('/favorites')}
+            className="text-blue-600 hover:text-blue-800 font-medium text-sm transition-colors"
+          >
+            全件見る ({total}件)
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/front/src/pages/user/MyPage.tsx
+++ b/front/src/pages/user/MyPage.tsx
@@ -8,6 +8,7 @@ import {
   ExclamationTriangleIcon,
 } from '@heroicons/react/24/outline';
 import { OrderHistoryPreview } from '../../components/user/OrderHistoryPreview';
+import { FavoritesPreview } from '../../components/user/FavoritesPreview';
 import { ORDER_HISTORY_PREVIEW_LIMIT } from '../../constants/order';
 import { ResignationModal } from '../../components/user/ResignationModal';
 import { resign } from '../../services/api/users';
@@ -44,6 +45,14 @@ export const MyPage: React.FC = () => {
             </div>
           )}
         </div>
+      </div>
+
+      {/* お気に入りセクション */}
+      <div className="bg-white rounded-lg shadow-md p-6 mb-6">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-bold">お気に入り</h2>
+        </div>
+        <FavoritesPreview />
       </div>
 
       {/* 購入履歴セクション */}


### PR DESCRIPTION
#129 

- [x] PR1: データベーススキーマとマイグレーション
- [x] PR2-1: バックエンドAPI実装（お気に入り追加）
- [x] PR2-2: バックエンドAPI実装（お気に入り削除）
- [x] PR2-3: バックエンドAPI実装（お気に入り取得）
- [x] PR2-4: 商品取得APIにお気に入りフラグを追加
- [x] PR3: 型定義の追加（shared）
- [x] PR4: フロントエンドAPIサービス実装
- [x] PR5: 商品詳細画面のお気に入りボタン実装
- [ ] **今これ→PR6: マイページのお気に入り表示実装**
- [ ] PR7: お気に入り一覧ページ実装
- [ ] PR8: ヘッダーからのお気に入り一覧ページへのリンク実装

<img width="980" height="753" alt="image" src="https://github.com/user-attachments/assets/0f88549e-13f5-407a-85e7-56cdc9966898" />
