### PR TITLE
ヘッダーのお気に入りアイコンからお気に入り一覧に遷移させる

### DIFF
--- a/front/src/components/layout/Header.tsx
+++ b/front/src/components/layout/Header.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router';
 import { HeaderProps } from '../../types';
 import { LogoutButton } from '../auth/LogoutButton';
 import { useCart } from '../../contexts/CartContext';
+import { useUser } from '../../contexts/UserContext';
 import {
   ShoppingCartIcon,
   HeartIcon,
@@ -25,6 +26,7 @@ const Header = React.forwardRef<HTMLElement, HeaderProps>(
     const [searchQuery, setSearchQuery] = useState('');
     const navigate = useNavigate();
     const { totalQuantity } = useCart();
+    const { isLoggedIn } = useUser();
 
     const handleSearch = (e: React.FormEvent) => {
       e.preventDefault();
@@ -81,8 +83,18 @@ const Header = React.forwardRef<HTMLElement, HeaderProps>(
 
             {/* アイコン */}
             <div className="flex items-center space-x-4">
-              {/* ウィッシュリストアイコン */}
-              <button className="p-2 text-gray-700">
+              {/* お気に入りアイコン */}
+              <button
+                onClick={() => {
+                  if (isLoggedIn()) {
+                    navigate('/favorites');
+                  } else {
+                    navigate('/auth/user/login');
+                  }
+                }}
+                className="p-2 text-gray-700 hover:text-gray-900"
+                aria-label="お気に入り"
+              >
                 <HeartIcon className="w-5 h-5" />
               </button>
               {/* ユーザーアイコン */}


### PR DESCRIPTION
#129 これでラストです

- [x] PR1: データベーススキーマとマイグレーション
- [x] PR2-1: バックエンドAPI実装（お気に入り追加）
- [x] PR2-2: バックエンドAPI実装（お気に入り削除）
- [x] PR2-3: バックエンドAPI実装（お気に入り取得）
- [x] PR2-4: 商品取得APIにお気に入りフラグを追加
- [x] PR3: 型定義の追加（shared）
- [x] PR4: フロントエンドAPIサービス実装
- [x] PR5: 商品詳細画面のお気に入りボタン実装
- [x] PR6: マイページのお気に入り表示実装
- [x] PR7: お気に入り一覧ページ実装
- [ ] **今これ→PR8: ヘッダーからのお気に入り一覧ページへのリンク実装**

https://github.com/user-attachments/assets/1a50f88b-42e8-407b-9f04-184c6eb61bd9


