### PR TITLE
DownloadToken,OrderItemFilesテーブルの追加

### DIFF
--- a/api/prisma/migrations/20260106214206_create_order_item_files_table/migration.sql
+++ b/api/prisma/migrations/20260106214206_create_order_item_files_table/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE `OrderItemFiles` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `orderId` INTEGER NOT NULL,
+    `itemId` INTEGER NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `OrderItemFiles_orderId_itemId_key`(`orderId`, `itemId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `OrderItemFiles` ADD CONSTRAINT `OrderItemFiles_orderId_fkey` FOREIGN KEY (`orderId`) REFERENCES `Orders`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `OrderItemFiles` ADD CONSTRAINT `OrderItemFiles_itemId_fkey` FOREIGN KEY (`itemId`) REFERENCES `Items`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/api/prisma/migrations/20260106221352_create_download_token_table/migration.sql
+++ b/api/prisma/migrations/20260106221352_create_download_token_table/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE `DownloadToken` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `orderId` INTEGER NOT NULL,
+    `userId` INTEGER NULL,
+    `token` VARCHAR(191) NOT NULL,
+    `usedAmount` INTEGER NOT NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `DownloadToken_orderId_key`(`orderId`),
+    UNIQUE INDEX `DownloadToken_userId_key`(`userId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `DownloadToken` ADD CONSTRAINT `DownloadToken_orderId_fkey` FOREIGN KEY (`orderId`) REFERENCES `Orders`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `DownloadToken` ADD CONSTRAINT `DownloadToken_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `Users`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -34,6 +34,20 @@ model CartItems {
   @@index([itemId])
 }
 
+model DownloadToken{
+    id  Int @id @default(autoincrement())
+    orderId Int @unique
+    userId  Int?    @unique
+    token   String
+    usedAmount  Int
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+
+    order Orders @relation(fields: [orderId], references: [id], onDelete: Cascade)
+    user Users? @relation(fields: [userId], references: [id],  onDelete: Cascade)
+    
+}
+
 model Inventory {
   id        Int      @id @default(autoincrement())
   amount    Int      @default(0)
@@ -61,6 +75,7 @@ model Items {
   Inventory  Inventory[]
   CartItems  CartItems[]
   OrderItems OrderItems[]
+  OrderItemFiles OrderItemFiles[]
   Reviews    Reviews[]
   Favorites  Favorites[]
 }
@@ -74,6 +89,7 @@ model ItemFiles {
     updatedAt DateTime @updatedAt
 
     item Items @relation(fields: [itemId], references: [id], onDelete: Cascade)
+
 
     @@index([itemId])
 }
@@ -105,7 +121,10 @@ model Orders {
   updatedAt      DateTime    @updatedAt
 
   user               Users?                    @relation(fields: [userId], references: [id], onDelete: SetNull)
+
+  downloadtoken     DownloadToken[]
   orderItems         OrderItems[]
+  orderItemFiles     OrderItemFiles[]
   paymentExternalIds OrderPaymentExternalIds[]
 
   @@index([userId])
@@ -124,6 +143,7 @@ model OrderPaymentExternalIds {
   updatedAt        DateTime @updatedAt
 
   order Orders @relation(fields: [orderId], references: [id], onDelete: Cascade)
+
 
   @@unique([provider, paymentSessionId])
   @@unique([provider, paymentId])
@@ -147,6 +167,20 @@ model OrderItems {
 
   @@unique([orderId, itemId])
   @@index([orderId])
+}
+
+model OrderItemFiles{
+    id      Int @id @default(autoincrement())
+    orderId Int 
+    itemId  Int?
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt()
+
+    order Orders @relation(fields: [orderId], references: [id], onDelete: Cascade)
+    item  Items? @relation(fields: [itemId], references: [id], onDelete: SetNull)
+
+    @@unique([orderId,itemId])
+
 }
 
 model Reviews {
@@ -198,6 +232,7 @@ model Users {
   updatedAt     DateTime @updatedAt
 
   cart                   Cart?
+  downloadtoken          DownloadToken?
   emailVerificationToken EmailVerificationToken?
   orders                 Orders[]
   reviews                Reviews[]


### PR DESCRIPTION
Orderに紐づくItemPathを管理するOrderItemFilesテーブルと、Order完了時にTokenを生成し、それを保存するためのDownloadTokenテーブルを作成しました。


<img width="734" height="288" alt="{32234D22-9DF1-45E4-B2BE-4F1C0548E1BD}" src="https://github.com/user-attachments/assets/a912bf4a-a840-48a4-b50b-6fb08819d367" />
DownloadTokenのフィールドにUsedAmountとUserIdが入っていると思います。
一応想定ではメール配信のみでのダウンロードを可能にしていますが、今後メール以外にも

- GuestはUsedAmountが1まで（つまり一回しかダウンロードできない）
- アカウント作成済の人は何回でもダウンロード可
このようなロジックを組むことで下記の条件を満たせるかな？と思います？（セキュリティ面でと言われると不安ですが）
<img width="531" height="83" alt="{40D7A040-9676-4C18-AF02-E1DE29561C7C}" src="https://github.com/user-attachments/assets/25ceafb8-da6f-4ca3-90f2-b0731bab7549" />


懸念点として、Itemが削除された際の対応が気になります。OrderItemFilesの設定をItemが削除されてもSetNullにしているため、購入後であればItemが削除されていてもPathがあればダウンロードを可能にしています。