### PR TITLE
OrderItemFilesの関係の修正と、DownloadTokenテーブルの作成

### DIFF
--- a/api/prisma/migrations/20260109113921_fix_item_file_relationship/migration.sql
+++ b/api/prisma/migrations/20260109113921_fix_item_file_relationship/migration.sql
@@ -1,0 +1,17 @@
+/*
+  Warnings:
+
+  - Made the column `itemId` on table `OrderItemFiles` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE `OrderItemFiles` DROP FOREIGN KEY `OrderItemFiles_itemId_fkey`;
+
+-- DropIndex
+DROP INDEX `OrderItemFiles_itemId_fkey` ON `OrderItemFiles`;
+
+-- AlterTable
+ALTER TABLE `OrderItemFiles` MODIFY `itemId` INTEGER NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE `OrderItemFiles` ADD CONSTRAINT `OrderItemFiles_itemId_fkey` FOREIGN KEY (`itemId`) REFERENCES `Items`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -172,12 +172,12 @@ model OrderItems {
 model OrderItemFiles{
     id      Int @id @default(autoincrement())
     orderId Int 
-    itemId  Int?
+    itemId  Int
     createdAt DateTime @default(now())
     updatedAt DateTime @updatedAt()
 
     order Orders @relation(fields: [orderId], references: [id], onDelete: Cascade)
-    item  Items? @relation(fields: [itemId], references: [id], onDelete: SetNull)
+    item  Items @relation(fields: [itemId], references: [id], onDelete: Cascade)
 
     @@unique([orderId,itemId])
 

--- a/api/src/contexts/items/domains/adapters/IDigitalItemStorageAdapter.ts
+++ b/api/src/contexts/items/domains/adapters/IDigitalItemStorageAdapter.ts
@@ -1,0 +1,5 @@
+export interface IDigitalItemStorageAdapter {
+  save(file: Buffer, filename: string, itemId: number): Promise<string>;
+  delete(filePath: string, itemId: number): Promise<void>;
+  getUrl(filePath: string, itemId: number): string;
+}

--- a/api/src/contexts/items/domains/entities/DownloadToken.ts
+++ b/api/src/contexts/items/domains/entities/DownloadToken.ts
@@ -1,0 +1,9 @@
+export type DownloadToken = {
+  id: number;
+  orderId: number;
+  userId: number | null;
+  token: string;
+  usedAmount: number;
+  createdAt: Date;
+  updatedAt: Date;
+};

--- a/api/src/contexts/items/domains/entities/ItemFile.ts
+++ b/api/src/contexts/items/domains/entities/ItemFile.ts
@@ -1,0 +1,8 @@
+export type ItemFile = {
+  readonly id: number;
+  readonly itemId: number;
+  readonly filename: string;
+  readonly path: string;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+};

--- a/api/src/contexts/items/domains/repositories/IDownloadTokenRepository.ts
+++ b/api/src/contexts/items/domains/repositories/IDownloadTokenRepository.ts
@@ -1,0 +1,13 @@
+import { DownloadToken } from '../entities/DownloadToken';
+
+export interface IDownloadTokenRepository {
+  findById(id: number): Promise<DownloadToken | null>;
+  findByOrderId(orderId: number): Promise<DownloadToken>;
+  findByToken(token: string): Promise<DownloadToken | null>;
+  create(
+    orderId: number,
+    userId: number | null,
+    token: string,
+  ): Promise<DownloadToken>;
+  incrementUsedAmount(id: number): Promise<void>;
+}

--- a/api/src/contexts/items/domains/repositories/IItemFilesRespository.ts
+++ b/api/src/contexts/items/domains/repositories/IItemFilesRespository.ts
@@ -1,0 +1,9 @@
+import { ItemFile } from '../entities/ItemFile';
+
+export interface IItemFileRepository {
+  findByItemId(itemId: number): Promise<ItemFile[]>;
+  findById(id: number): Promise<ItemFile | null>;
+  create(itemId: number, filename: string, path: string): Promise<ItemFile>;
+  delete(id: number): Promise<boolean>;
+  deleteByItemId(itemId: number): Promise<boolean>;
+}

--- a/api/src/contexts/items/infrastructures/adapters/LocalDigitalItemStorageAdapter.ts
+++ b/api/src/contexts/items/infrastructures/adapters/LocalDigitalItemStorageAdapter.ts
@@ -1,0 +1,63 @@
+import * as path from 'path';
+import { promises as fs } from 'fs';
+import { IDigitalItemStorageAdapter } from '../../domains/adapters/IDigitalItemStorageAdapter';
+
+export class LocalDigitalItemStorageAdapter
+  implements IDigitalItemStorageAdapter
+{
+  private readonly uploadDir: string;
+
+  constructor(uploadDir: string) {
+    this.uploadDir = uploadDir;
+  }
+
+  /**
+   * zipをローカルに保存して「filePath（storageKey）」を返す
+   * 例: digital/items/42/product.zip
+   */
+  async save(file: Buffer, filename: string, itemId: number): Promise<string> {
+    // ① 拡張子チェック（zipのみ許可）
+    const ext = path.extname(filename).toLowerCase();
+    if (ext !== '.zip') {
+      throw new Error('Digital item must be a zip file');
+    }
+
+    // ② DBに保存する filePath（storageKey）を作る（uploadDirを含めない）
+    const filePath = path.join('digital', 'items', itemId.toString(), filename);
+
+    // ③ 実際の保存先（絶対パス）
+    const fullPath = path.join(this.uploadDir, filePath);
+
+    // ④ ディレクトリ作成
+    await fs.mkdir(path.dirname(fullPath), { recursive: true });
+
+    // ⑤ 書き込み
+    await fs.writeFile(fullPath, file);
+
+    return filePath;
+  }
+
+  /**
+   * ローカルから削除
+   * filePath は save() で返した値をそのまま渡す想定
+   */
+  async delete(filePath: string, itemId: number): Promise<void> {
+    // 安全のため itemId と filePath が一致してるか軽く検証（任意）
+    const normalized = filePath.replace(/\\/g, '/');
+    if (!normalized.startsWith(`digital/items/${itemId}/`)) {
+      throw new Error('Invalid filePath for the itemId');
+    }
+
+    const fullPath = path.join(this.uploadDir, filePath);
+    await fs.unlink(fullPath);
+  }
+
+  getUrl(filePath: string, itemId: number): string {
+    const normalized = filePath.replace(/\\/g, '/');
+    if (!normalized.startsWith(`digital/items/${itemId}/`)) {
+      throw new Error('Invalid filePath for the itemId');
+    }
+
+    return `/static/${normalized}`;
+  }
+}

--- a/api/src/contexts/items/infrastructures/repositories/DownloadTokenRepository.ts
+++ b/api/src/contexts/items/infrastructures/repositories/DownloadTokenRepository.ts
@@ -1,0 +1,57 @@
+import { PrismaClient } from '@prisma/client';
+import { IDownloadTokenRepository } from '../../domains/repositories/IDownloadTokenRepository';
+import { DownloadToken } from '../../domains/entities/DownloadToken';
+
+export class DownloadTokenRepository implements IDownloadTokenRepository {
+  constructor(private prisma: PrismaClient) {}
+
+  async findById(id: number): Promise<DownloadToken | null> {
+    const downloadtoken = await this.prisma.downloadToken.findUnique({
+      where: { id },
+    });
+    return downloadtoken;
+  }
+
+  async findByOrderId(orderId: number): Promise<DownloadToken> {
+    const downloadtoken = await this.prisma.downloadToken.findUnique({
+      where: { orderId },
+    });
+    if (!downloadtoken) {
+      throw new Error('DownloadToken not found');
+    }
+    return downloadtoken;
+  }
+
+  async findByToken(token: string): Promise<DownloadToken | null> {
+    const downloadtoken = await this.prisma.downloadToken.findFirst({
+      where: { token },
+    });
+    return downloadtoken;
+  }
+
+  async create(
+    orderId: number,
+    userId: number | null,
+    token: string,
+  ): Promise<DownloadToken> {
+    const downloadtoken = await this.prisma.downloadToken.create({
+      data: {
+        orderId,
+        userId,
+        token,
+        usedAmount: 0,
+      },
+    });
+    return downloadtoken;
+  }
+  async incrementUsedAmount(id: number): Promise<void> {
+    await this.prisma.downloadToken.update({
+      where: { id },
+      data: {
+        usedAmount: {
+          increment: 1,
+        },
+      },
+    });
+  }
+}

--- a/api/src/contexts/items/infrastructures/repositories/ItemFileRepository.ts
+++ b/api/src/contexts/items/infrastructures/repositories/ItemFileRepository.ts
@@ -1,0 +1,83 @@
+import { PrismaClient } from '@prisma/client';
+import { IItemFileRepository } from '../../domains/repositories/IItemFilesRespository';
+import { ItemFile } from '../../domains/entities/ItemFile';
+
+export class ItemFileRepository implements IItemFileRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(id: number): Promise<ItemFile | null> {
+    const itemfile = await this.prisma.itemFiles.findUnique({
+      where: { id },
+    });
+
+    if (!itemfile) {
+      return null;
+    }
+
+    return {
+      id: itemfile.id,
+      itemId: itemfile.itemId,
+      filename: itemfile.filename,
+      path: itemfile.path,
+      createdAt: itemfile.createdAt,
+      updatedAt: itemfile.updatedAt,
+    };
+  }
+
+  async findByItemId(itemId: number): Promise<ItemFile[]> {
+    const itemfiles = await this.prisma.itemFiles.findMany({
+      where: { itemId },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    return itemfiles.map((itemfile) => ({
+      id: itemfile.id,
+      itemId: itemfile.itemId,
+      filename: itemfile.filename,
+      path: itemfile.path,
+      createdAt: itemfile.createdAt,
+      updatedAt: itemfile.updatedAt,
+    }));
+  }
+
+  async create(
+    itemId: number,
+    filename: string,
+    path: string,
+  ): Promise<ItemFile> {
+    const itemfile = await this.prisma.itemFiles.create({
+      data: {
+        itemId,
+        filename,
+        path,
+      },
+    });
+
+    return {
+      id: itemfile.id,
+      itemId: itemfile.itemId,
+      filename: itemfile.filename,
+      path: itemfile.path,
+      createdAt: itemfile.createdAt,
+      updatedAt: itemfile.updatedAt,
+    };
+  }
+
+  async delete(id: number): Promise<boolean> {
+    try {
+      await this.prisma.itemFiles.delete({
+        where: { id },
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async deleteByItemId(itemId: number): Promise<boolean> {
+    await this.prisma.itemFiles.deleteMany({
+      where: { itemId },
+    });
+    return true;
+  }
+}

--- a/api/src/contexts/orders/domains/entities/OrderItemFile.ts
+++ b/api/src/contexts/orders/domains/entities/OrderItemFile.ts
@@ -1,0 +1,7 @@
+export type OrderItemFile = {
+  readonly id: number;
+  readonly orderId: number;
+  readonly itemId: number;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+};

--- a/api/src/contexts/orders/domains/repositories/IOrderItemFileRepository.ts
+++ b/api/src/contexts/orders/domains/repositories/IOrderItemFileRepository.ts
@@ -1,0 +1,7 @@
+import { OrderItemFile } from '../entities/OrderItemFile';
+
+export interface IOrderItemFileRepository {
+  findById(id: number): Promise<OrderItemFile>;
+  findByOrderId(orderId: number): Promise<OrderItemFile[]>;
+  create(orderId: number, itemId: number): Promise<OrderItemFile>;
+}

--- a/api/src/contexts/orders/infrastructures/repositories/OrderItemFileRepository.ts
+++ b/api/src/contexts/orders/infrastructures/repositories/OrderItemFileRepository.ts
@@ -1,0 +1,56 @@
+import { OrderItemFile } from '../../domains/entities/OrderItemFile';
+import { IOrderItemFileRepository } from '../../domains/repositories/IOrderItemFileRepository';
+import { PrismaClient, Prisma } from '@prisma/client';
+
+export class OrderItemFileRepository implements IOrderItemFileRepository {
+  constructor(private readonly prisma: PrismaClient) {}
+
+  async findById(id: number): Promise<OrderItemFile> {
+    const orderItemFile = await this.prisma.orderItemFiles.findUnique({
+      where: { id },
+    });
+
+    if (!orderItemFile) {
+      throw new Error(`OrderItemFile with id ${id} not found`);
+    }
+
+    return {
+      id: orderItemFile.id,
+      orderId: orderItemFile.orderId,
+      itemId: orderItemFile.itemId,
+      createdAt: orderItemFile.createdAt,
+      updatedAt: orderItemFile.updatedAt,
+    };
+  }
+
+  async findByOrderId(orderId: number): Promise<OrderItemFile[]> {
+    const orderItemFiles = await this.prisma.orderItemFiles.findMany({
+      where: { orderId },
+    });
+
+    return orderItemFiles.map((orderItemFile) => ({
+      id: orderItemFile.id,
+      orderId: orderItemFile.orderId,
+      itemId: orderItemFile.itemId,
+      createdAt: orderItemFile.createdAt,
+      updatedAt: orderItemFile.updatedAt,
+    }));
+  }
+
+  async create(orderId: number, itemId: number): Promise<OrderItemFile> {
+    const orderItemFile = await this.prisma.orderItemFiles.create({
+      data: {
+        orderId,
+        itemId,
+      },
+    } as Prisma.OrderItemFilesCreateArgs);
+
+    return {
+      id: orderItemFile.id,
+      orderId: orderItemFile.orderId,
+      itemId: orderItemFile.itemId,
+      createdAt: orderItemFile.createdAt,
+      updatedAt: orderItemFile.updatedAt,
+    };
+  }
+}

--- a/api/src/contexts/orders/interactors/CreateOrderItemFileInteractor.ts
+++ b/api/src/contexts/orders/interactors/CreateOrderItemFileInteractor.ts
@@ -1,0 +1,49 @@
+import { OrderItemFile } from '../domains/entities/OrderItemFile';
+import { IOrderItemFileRepository } from '../domains/repositories/IOrderItemFileRepository';
+import { ICreateOrderItemFileInteractor } from '../usecases/ICreateOrderItemFileInteractor';
+import { IItemRepository } from 'src/contexts/items/domains/repositories/IItemRepository';
+
+export class CreateOrderItemFileInteractor
+  implements ICreateOrderItemFileInteractor
+{
+  constructor(
+    private readonly itemRepository: IItemRepository,
+    private readonly orderItemFileRepository: IOrderItemFileRepository,
+  ) {}
+
+  async createByitemId(orderId: number, itemId: number) {
+    const item = await this.itemRepository.findById(itemId);
+
+    if (!item) {
+      throw new Error('Item not found');
+    }
+
+    const type = item.type;
+
+    if (type == 2) {
+      const orderItemFile = await this.orderItemFileRepository.create(
+        orderId,
+        itemId,
+      );
+      return orderItemFile;
+    } else {
+      throw new Error('Item is not a digital product');
+    }
+  }
+
+  async createByOrderId(orderId: number): Promise<OrderItemFile[]> {
+    const order = await this.orderItemFileRepository.findByOrderId(orderId);
+    const items = await order.map(async (orderItemFile) => {
+      const item = await this.itemRepository.findById(orderItemFile.itemId);
+      if (item && item.type == 2) {
+        await this.orderItemFileRepository.create(
+          orderId,
+          orderItemFile.itemId,
+        );
+      }
+    });
+    return Promise.all(items).then(() => {
+      return this.orderItemFileRepository.findByOrderId(orderId);
+    });
+  }
+}

--- a/api/src/contexts/orders/usecases/ICreateOrderItemFileInteractor.ts
+++ b/api/src/contexts/orders/usecases/ICreateOrderItemFileInteractor.ts
@@ -1,0 +1,6 @@
+import { OrderItemFile } from '../domains/entities/OrderItemFile';
+
+export interface ICreateOrderItemFileInteractor {
+  createByitemId(orderId: number, itemId: number): Promise<OrderItemFile>;
+  createByOrderId(orderId: number): Promise<OrderItemFile[]>;
+}

--- a/api/src/utils/downloadtoken.ts
+++ b/api/src/utils/downloadtoken.ts
@@ -1,0 +1,5 @@
+import { randomUUID } from 'crypto';
+
+export const generateDownloadToken = (): string => {
+  return randomUUID();
+};


### PR DESCRIPTION
OrderItemFilesはOrderのデジタル製品のみのItemIdを保存するようにEntitiyを変更しました。

DownloadTokenは
OrderIdを元に単純にUUIDを保存するToken入るようになっています。