### PR TITLE
ログアウトと退会のUI改善

### DIFF
--- a/front/src/components/auth/LogoutButton.tsx
+++ b/front/src/components/auth/LogoutButton.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useNavigate } from 'react-router';
 import { logout } from '../../services/api/auth';
 import { useUser } from '../../contexts/UserContext';
+import { LogoutConfirmationModal } from './LogoutConfirmationModal';
 
 interface LogoutButtonProps {
   className?: string;
@@ -14,6 +15,7 @@ export const LogoutButton: React.FC<LogoutButtonProps> = ({
 }) => {
   const navigate = useNavigate();
   const { clearUser } = useUser();
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleLogout = async () => {
     try {
@@ -27,12 +29,20 @@ export const LogoutButton: React.FC<LogoutButtonProps> = ({
       }
     } catch (error) {
       console.error('Logout failed:', error);
+      throw error;
     }
   };
 
   return (
-    <button onClick={handleLogout} className={className}>
-      ログアウト
-    </button>
+    <>
+      <button onClick={() => setIsModalOpen(true)} className={className}>
+        ログアウト
+      </button>
+      <LogoutConfirmationModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        onConfirm={handleLogout}
+      />
+    </>
   );
 };

--- a/front/src/components/auth/LogoutConfirmationModal.tsx
+++ b/front/src/components/auth/LogoutConfirmationModal.tsx
@@ -1,29 +1,24 @@
 import React, { useState } from 'react';
 import {
   XMarkIcon,
-  ExclamationTriangleIcon,
+  ArrowRightOnRectangleIcon,
 } from '@heroicons/react/24/outline';
 
-interface ResignationModalProps {
+interface LogoutConfirmationModalProps {
   isOpen: boolean;
   onClose: () => void;
   onConfirm: () => Promise<void>;
 }
 
-export const ResignationModal: React.FC<ResignationModalProps> = ({
-  isOpen,
-  onClose,
-  onConfirm,
-}) => {
-  const [isConfirmed, setIsConfirmed] = useState(false);
+export const LogoutConfirmationModal: React.FC<
+  LogoutConfirmationModalProps
+> = ({ isOpen, onClose, onConfirm }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   if (!isOpen) return null;
 
   const handleConfirm = async () => {
-    if (!isConfirmed) return;
-
     setIsLoading(true);
     setError(null);
 
@@ -32,7 +27,7 @@ export const ResignationModal: React.FC<ResignationModalProps> = ({
     } catch (err: any) {
       setError(
         err.message ||
-          '退会できませんでした。しばらく時間をおいて再度お試しください。',
+          'ログアウトできませんでした。しばらく時間をおいて再度お試しください。',
       );
       setIsLoading(false);
     }
@@ -40,7 +35,6 @@ export const ResignationModal: React.FC<ResignationModalProps> = ({
 
   const handleClose = () => {
     if (isLoading) return;
-    setIsConfirmed(false);
     setError(null);
     onClose();
   };
@@ -68,43 +62,21 @@ export const ResignationModal: React.FC<ResignationModalProps> = ({
           {/* アイコンとタイトル */}
           <div className="flex items-center space-x-3 mb-4">
             <div className="flex-shrink-0">
-              <ExclamationTriangleIcon className="w-8 h-8 text-red-600" />
+              <ArrowRightOnRectangleIcon className="w-8 h-8 text-gray-600" />
             </div>
-            <h2 className="text-2xl font-bold text-gray-900">退会しますか？</h2>
+            <h2 className="text-2xl font-bold text-gray-900">
+              ログアウトしますか？
+            </h2>
           </div>
 
-          {/* 警告メッセージ */}
+          {/* メッセージ */}
           <div className="mb-6">
             <p className="text-gray-700 mb-4">
-              退会すると、以下の情報はすべて削除され、元に戻すことはできません：
+              ログアウトすると、ゲストに切り替わります。
             </p>
-            <ul className="list-disc list-inside space-y-2 text-gray-600 mb-4 ml-4">
-              <li>あなたのアカウント情報</li>
-              <li>これまでの購入履歴</li>
-              <li>お気に入り商品</li>
-              <li>カートに入れた商品</li>
-            </ul>
-            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-              <p className="text-red-800 font-medium text-sm">
-                この操作は取り消せません。本当に退会してよろしいですか？
-              </p>
-            </div>
-          </div>
-
-          {/* 確認チェックボックス */}
-          <div className="mb-6">
-            <label className="flex items-start space-x-3 cursor-pointer">
-              <input
-                type="checkbox"
-                checked={isConfirmed}
-                onChange={(e) => setIsConfirmed(e.target.checked)}
-                disabled={isLoading}
-                className="mt-1 w-4 h-4 text-red-600 border-gray-300 rounded focus:ring-red-500 disabled:opacity-50"
-              />
-              <span className="text-gray-700 text-sm">
-                上記の内容を理解しました
-              </span>
-            </label>
+            <p className="text-gray-600 text-sm">
+              再度ご利用になる場合は、ログイン画面からメールアドレスとパスワードを入力してください。
+            </p>
           </div>
 
           {/* エラーメッセージ */}
@@ -125,10 +97,10 @@ export const ResignationModal: React.FC<ResignationModalProps> = ({
             </button>
             <button
               onClick={handleConfirm}
-              disabled={!isConfirmed || isLoading}
-              className="flex-1 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed font-medium"
+              disabled={isLoading}
+              className="flex-1 px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed font-medium"
             >
-              {isLoading ? '退会しています...' : '退会する'}
+              {isLoading ? 'ログアウトしています...' : 'ログアウト'}
             </button>
           </div>
         </div>

--- a/front/src/components/user/ResignationModal.tsx
+++ b/front/src/components/user/ResignationModal.tsx
@@ -93,13 +93,13 @@ export const ResignationModal: React.FC<ResignationModalProps> = ({
 
           {/* 確認チェックボックス */}
           <div className="mb-6">
-            <label className="flex items-start space-x-3 cursor-pointer">
+            <label className="flex items-center space-x-3 cursor-pointer">
               <input
                 type="checkbox"
                 checked={isConfirmed}
                 onChange={(e) => setIsConfirmed(e.target.checked)}
                 disabled={isLoading}
-                className="mt-1 w-4 h-4 text-red-600 border-gray-300 rounded focus:ring-red-500 disabled:opacity-50"
+                className="w-4 h-4 text-red-600 border-gray-300 rounded focus:ring-red-500 disabled:opacity-50 flex-shrink-0"
               />
               <span className="text-gray-700 text-sm">
                 上記の内容を理解しました

--- a/front/src/pages/user/MyPage.tsx
+++ b/front/src/pages/user/MyPage.tsx
@@ -5,9 +5,11 @@ import {
   CubeIcon,
   ClipboardDocumentListIcon,
   ChevronRightIcon,
-  ExclamationTriangleIcon,
   LockClosedIcon,
   ArrowRightIcon,
+  EnvelopeIcon,
+  UserIcon,
+  ExclamationTriangleIcon,
 } from '@heroicons/react/24/outline';
 import { OrderHistoryPreview } from '../../components/user/OrderHistoryPreview';
 import { FavoritesPreview } from '../../components/user/FavoritesPreview';
@@ -153,25 +155,52 @@ export const MyPage: React.FC = () => {
         </div>
       )}
 
-      {/* 退会セクション */}
-      <div className="bg-white rounded-lg shadow-md p-6 border-t-2 border-red-100">
-        <div className="flex items-start space-x-3 mb-4">
-          <ExclamationTriangleIcon className="w-6 h-6 text-red-600 flex-shrink-0 mt-0.5" />
-          <div className="flex-1">
-            <h2 className="text-xl font-bold text-gray-900 mb-2">
-              アカウント設定
-            </h2>
-            <p className="text-gray-600 text-sm mb-4">
+      {/* アカウント設定セクション */}
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <h2 className="text-xl font-bold text-gray-900 mb-6">アカウント設定</h2>
+        <div className="flex flex-col space-y-3 mb-6">
+          <button
+            onClick={() => {
+              // ハリボテ実装: 将来的にプロフィール編集モーダルを表示
+              alert('プロフィール編集機能は準備中です');
+            }}
+            className="self-start flex items-center space-x-2 py-2 text-gray-700 hover:text-gray-900 transition-colors text-sm font-medium"
+          >
+            <UserIcon className="w-5 h-5 text-gray-500" />
+            <span>プロフィールを編集</span>
+          </button>
+          <button
+            onClick={() => {
+              // ハリボテ実装: 将来的にメールアドレス変更モーダルを表示
+              alert('メールアドレス変更機能は準備中です');
+            }}
+            className="self-start flex items-center space-x-2 py-2 text-gray-700 hover:text-gray-900 transition-colors text-sm font-medium"
+          >
+            <EnvelopeIcon className="w-5 h-5 text-gray-500" />
+            <span>メールアドレスを変更</span>
+          </button>
+        </div>
+
+        {/* Danger Zone */}
+        <div className="border-t border-red-200 pt-6 mt-6">
+          <div className="mb-4">
+            <div className="flex items-center space-x-2 mb-2">
+              <ExclamationTriangleIcon className="w-5 h-5 text-red-600 flex-shrink-0" />
+              <h3 className="text-lg font-semibold text-red-600">
+                アカウントの削除
+              </h3>
+            </div>
+            <p className="text-gray-600 text-sm ml-7">
               アカウントを削除すると、すべてのデータが永久に削除され、復元できません。
             </p>
           </div>
+          <button
+            onClick={() => setIsResignationModalOpen(true)}
+            className="px-4 py-2 text-red-600 border border-red-300 rounded-lg hover:bg-red-50 transition-colors font-medium text-sm whitespace-nowrap"
+          >
+            退会する
+          </button>
         </div>
-        <button
-          onClick={() => setIsResignationModalOpen(true)}
-          className="px-4 py-2 text-red-600 border border-red-300 rounded-lg hover:bg-red-50 transition-colors font-medium text-sm"
-        >
-          アカウントを退会する
-        </button>
       </div>
 
       {/* 退会確認モーダル */}


### PR DESCRIPTION
#282 

ログアウト時にモーダルを出す

<img width="466" height="274" alt="image" src="https://github.com/user-attachments/assets/8cf35afc-e6b4-4cc5-af02-d897fa02a78b" />


マイページの退会周りのUIを改善

<img width="827" height="340" alt="image" src="https://github.com/user-attachments/assets/0b204ac9-a687-42ed-b80d-b1fe81a65961" />


退会時のモーダルの文言調整

<img width="473" height="490" alt="image" src="https://github.com/user-attachments/assets/5ed04cc8-3e35-4332-8cb9-b41be31b7104" />
