### PR TITLE
タグを使っている商品数を返すAPI実装

### DIFF
--- a/api/src/contexts/tags/controllers/GetTagUsageCountController.ts
+++ b/api/src/contexts/tags/controllers/GetTagUsageCountController.ts
@@ -1,0 +1,37 @@
+import express from 'express';
+import { GetRes } from '@shared/types/gets';
+import { IGetTagUsageCountInteractor } from '../usecases/IGetTagUsageCountInteractor';
+
+export class GetTagUsageCountController {
+  constructor(
+    private readonly getTagUsageCountInteractor: IGetTagUsageCountInteractor,
+  ) {}
+
+  async execute(
+    req: express.Request<{ id: string }>,
+    res: express.Response<
+      GetRes['/admin/tags/:id/usage-count'] | { message: string }
+    >,
+  ) {
+    try {
+      const tagId = parseInt(req.params.id, 10);
+
+      if (isNaN(tagId) || tagId < 1) {
+        return res.status(400).json({ message: 'Invalid tag ID' });
+      }
+
+      const count = await this.getTagUsageCountInteractor.execute(tagId);
+
+      return res.status(200).json({
+        count,
+      });
+    } catch (error) {
+      if (error instanceof Error && error.message === 'Tag not found') {
+        return res.status(404).json({ message: 'Tag not found' });
+      }
+
+      console.error('Error getting tag usage count:', error);
+      return res.status(500).json({ message: 'Internal server error' });
+    }
+  }
+}

--- a/api/src/contexts/tags/domains/repositories/ITagRepository.ts
+++ b/api/src/contexts/tags/domains/repositories/ITagRepository.ts
@@ -8,8 +8,8 @@ export interface ITagRepository {
   create(name: string): Promise<Tag>;
   update(id: number, name: string): Promise<Tag | null>;
   delete(id: number): Promise<boolean>;
-  // 商品とタグの関連付け
   attachTagsToItem(itemId: number, tagIds: number[]): Promise<void>;
   detachTagsFromItem(itemId: number, tagIds: number[]): Promise<void>;
   replaceItemTags(itemId: number, tagIds: number[]): Promise<void>;
+  getUsageCount(id: number): Promise<number>;
 }

--- a/api/src/contexts/tags/index.ts
+++ b/api/src/contexts/tags/index.ts
@@ -6,6 +6,8 @@ import { UpdateTagController } from './controllers/UpdateTagController';
 import { UpdateTagInteractor } from './interactors/UpdateTagInteractor';
 import { DeleteTagController } from './controllers/DeleteTagController';
 import { DeleteTagInteractor } from './interactors/DeleteTagInteractor';
+import { GetTagUsageCountController } from './controllers/GetTagUsageCountController';
+import { GetTagUsageCountInteractor } from './interactors/GetTagUsageCountInteractor';
 import { TagRepository } from './infrastructures/repositories/TagRepository';
 import { prisma } from '../../libs/prisma';
 import express from 'express';
@@ -27,6 +29,13 @@ const updateTagController = new UpdateTagController(updateTagInteractor);
 const deleteTagInteractor = new DeleteTagInteractor(tagRepository);
 const deleteTagController = new DeleteTagController(deleteTagInteractor);
 
+const getTagUsageCountInteractor = new GetTagUsageCountInteractor(
+  tagRepository,
+);
+const getTagUsageCountController = new GetTagUsageCountController(
+  getTagUsageCountInteractor,
+);
+
 adminTagsRouter.use(verifyAccessToken);
 adminTagsRouter.use(verifyAdmin);
 
@@ -45,6 +54,11 @@ adminTagsRouter.patch(
 adminTagsRouter.delete(
   '/:id',
   deleteTagController.execute.bind(deleteTagController),
+);
+
+adminTagsRouter.get(
+  '/:id/usage-count',
+  getTagUsageCountController.execute.bind(getTagUsageCountController),
 );
 
 export { adminTagsRouter };

--- a/api/src/contexts/tags/infrastructures/repositories/TagRepository.ts
+++ b/api/src/contexts/tags/infrastructures/repositories/TagRepository.ts
@@ -160,4 +160,11 @@ export class TagRepository implements ITagRepository {
       }
     });
   }
+
+  async getUsageCount(id: number): Promise<number> {
+    const count = await this.prisma.itemTags.count({
+      where: { tagId: id },
+    });
+    return count;
+  }
 }

--- a/api/src/contexts/tags/interactors/GetTagUsageCountInteractor.ts
+++ b/api/src/contexts/tags/interactors/GetTagUsageCountInteractor.ts
@@ -1,0 +1,15 @@
+import { IGetTagUsageCountInteractor } from '../usecases/IGetTagUsageCountInteractor';
+import { ITagRepository } from '../domains/repositories/ITagRepository';
+
+export class GetTagUsageCountInteractor implements IGetTagUsageCountInteractor {
+  constructor(private readonly tagRepository: ITagRepository) {}
+
+  async execute(id: number): Promise<number> {
+    const tag = await this.tagRepository.findById(id);
+    if (!tag) {
+      throw new Error('Tag not found');
+    }
+
+    return await this.tagRepository.getUsageCount(id);
+  }
+}

--- a/api/src/contexts/tags/usecases/IGetTagUsageCountInteractor.ts
+++ b/api/src/contexts/tags/usecases/IGetTagUsageCountInteractor.ts
@@ -1,0 +1,3 @@
+export interface IGetTagUsageCountInteractor {
+  execute(id: number): Promise<number>;
+}

--- a/shared/types/gets.ts
+++ b/shared/types/gets.ts
@@ -105,4 +105,7 @@ export type GetRes = {
   '/admin/tags': {
     tags: Tag[];
   };
+  '/admin/tags/:id/usage-count': {
+    count: number;
+  };
 };


### PR DESCRIPTION
タグを削除するときに何件の商品で使われているか表示するため

```
localhost:8000/admin/tags/1/usage-count

>> {"count":2} 
```